### PR TITLE
Jets3 Exception if a file is copied twice

### DIFF
--- a/src/test/java/com/intridea/io/vfs/provider/s3/S3ProviderTest.java
+++ b/src/test/java/com/intridea/io/vfs/provider/s3/S3ProviderTest.java
@@ -141,6 +141,30 @@ public class S3ProviderTest {
     }
 
     @Test(dependsOnMethods={"createFileOk"})
+    public void upload_multiple() throws Exception {
+        FileObject dest = fsManager.resolveFile("s3://" + bucketName + "/test-place/backup.zip");
+
+        // Delete file if exists
+        if (dest.exists()) {
+            dest.delete();
+        }
+
+        // Copy data
+        final File backupFile = new File(BACKUP_ZIP);
+
+        Assert.assertTrue(backupFile.exists(), "Backup file should exists");
+
+        FileObject src = fsManager.resolveFile(backupFile.getAbsolutePath());
+
+        // copy twice
+        dest.copyFrom(src, Selectors.SELECT_SELF);
+        Thread.sleep(2000L);
+        dest.copyFrom(src, Selectors.SELECT_SELF);
+
+        Assert.assertTrue(dest.exists() && dest.getType().equals(FileType.FILE));
+    }
+
+    @Test(dependsOnMethods={"createFileOk"})
     public void uploadBigFile() throws FileNotFoundException, IOException {
         FileObject dest = fsManager.resolveFile("s3://" + bucketName + "/big_file.iso");
 


### PR DESCRIPTION
If I copy a file twice, like in the added testcase, I got a org.jets3t.service.ServiceException because of a duplication of HTTP Headers.

The duplicated header is: x-amz-meta-last-modified and x-amz-meta-Last-Modified. Notice the two uppercase letters in the last one.

I didn't have much time for investigation, but I think this might by caused by the following issue in jets3 which got resolved for the upcoming version:

https://bitbucket.org/jmurty/jets3t/issue/96/object-metadata-case-sensitivity

If I have some time, I will try to build and use the current SNAPSHOT of jets3 to prove this assumption. But maybe in between you have another idea to this.

Here is the surefire-report:

---
## Test set: TestSuite

Tests run: 24, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 80.776 sec <<< FAILURE!
upload_multiple(com.intridea.io.vfs.provider.s3.S3ProviderTest)  Time elapsed: 12.542 sec  <<< FAILURE!
org.apache.commons.vfs.FileSystemException: Could not copy "file:///[...]/vfs-s3/src/test/resources/backup.zip" to "s3://vfs-s3-tests/test-place/backup.zip".
    at com.intridea.io.vfs.provider.s3.S3FileObject.copyFrom(S3FileObject.java:636)
    at com.intridea.io.vfs.provider.s3.S3ProviderTest.upload_multiple(S3ProviderTest.java:162)
Caused by: org.apache.commons.vfs.FileSystemException: Could not close the output stream for file "s3://vfs-s3-tests-moritz/test-place/backup.zip".
    at org.apache.commons.vfs.provider.DefaultFileContent$FileContentOutputStream.close(DefaultFileContent.java:599)
    at org.apache.commons.vfs.FileUtil.copyContent(FileUtil.java:107)
    at com.intridea.io.vfs.provider.s3.S3FileObject.doCopy(S3FileObject.java:673)
    at com.intridea.io.vfs.provider.s3.S3FileObject.copyFrom(S3FileObject.java:627)
    ... 36 more
Caused by: java.io.IOException: org.jets3t.service.ServiceException: HTTP header name occurs multiple times in request with different values, probably due to mismatched capitalization when setting metadata names. Duplicate metadata name: 'x-amz-meta-last-modified', All metadata: {x-amz-meta-Last-Modified=Mon Jul 18 16:01:04 CEST 2011, Content-Length=996166, x-amz-meta-last-modified=Mon Jul 18 16:01:03 CEST 2011, x-amz-meta-request-id=[...], x-amz-meta-id-2=[...], x-amz-meta-Date=Mon Jul 18 16:01:15 CEST 2011, x-amz-meta-ETag="[...]", Content-Type=application/octet-stream}
    at com.intridea.io.vfs.provider.s3.S3FileObject$S3OutputStream.onClose(S3FileObject.java:728)
    at org.apache.commons.vfs.util.MonitorOutputStream.close(MonitorOutputStream.java:63)
    at java.io.FilterOutputStream.close(FilterOutputStream.java:143)
    at org.apache.commons.vfs.util.MonitorOutputStream.close(MonitorOutputStream.java:53)
    at org.apache.commons.vfs.provider.DefaultFileContent$FileContentOutputStream.close(DefaultFileContent.java:595)
    ... 39 more
Caused by: org.jets3t.service.ServiceException: HTTP header name occurs multiple times in request with different values, probably due to mismatched capitalization when setting metadata names. Duplicate metadata name: 'x-amz-meta-last-modified', All metadata: {x-amz-meta-Last-Modified=Mon Jul 18 16:01:04 CEST 2011, Content-Length=996166, x-amz-meta-last-modified=Mon Jul 18 16:01:03 CEST 2011, x-amz-meta-request-id=[...], x-amz-meta-id-2=[...], x-amz-meta-Date=Mon Jul 18 16:01:15 CEST 2011, x-amz-meta-ETag="[...]", Content-Type=application/octet-stream}
    at org.jets3t.service.impl.rest.httpclient.RestStorageService.addMetadataToHeaders(RestStorageService.java:813)
    at org.jets3t.service.impl.rest.httpclient.RestStorageService.performRestPut(RestStorageService.java:950)
    at org.jets3t.service.impl.rest.httpclient.RestStorageService.createObjectImpl(RestStorageService.java:1695)
    at org.jets3t.service.impl.rest.httpclient.RestStorageService.putObjectWithRequestEntityImpl(RestStorageService.java:1630)
    at org.jets3t.service.impl.rest.httpclient.RestStorageService.putObjectImpl(RestStorageService.java:1617)
    at org.jets3t.service.StorageService.putObject(StorageService.java:815)
    at com.intridea.io.vfs.provider.s3.S3FileObject$S3OutputStream.onClose(S3FileObject.java:726)
    ... 43 more

---

TL;DR: This pull requests contains a failing test which copies a file twice to S3.
