### PR TITLE
ApacheVFS 2.0 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>commons-vfs</groupId>
-            <artifactId>commons-vfs</artifactId>
-            <version>1.0</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-vfs2</artifactId>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.intridea.io</groupId>
     <artifactId>vfs-s3</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>vfs-s3</name>
 

--- a/src/main/java/com/intridea/io/vfs/operations/IAclGetter.java
+++ b/src/main/java/com/intridea/io/vfs/operations/IAclGetter.java
@@ -1,7 +1,7 @@
 package com.intridea.io.vfs.operations;
 
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.operations.FileOperation;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.operations.FileOperation;
 
 /**
  * Interface for getting file Access Control List.
@@ -34,5 +34,6 @@ public interface IAclGetter extends FileOperation {
      * Executes getter operation.
      * Must be called before aby other operation methods
      */
+    @Override
     void process() throws FileSystemException;
 }

--- a/src/main/java/com/intridea/io/vfs/operations/IAclSetter.java
+++ b/src/main/java/com/intridea/io/vfs/operations/IAclSetter.java
@@ -1,7 +1,7 @@
 package com.intridea.io.vfs.operations;
 
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.operations.FileOperation;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.operations.FileOperation;
 
 /**
  * Interface for setting file Access Control List.
@@ -20,6 +20,7 @@ public interface IAclSetter extends FileOperation {
      * Executes setter operations.
      * Must be called after setAcl.
      */
+    @Override
     void process() throws FileSystemException;
 
 }

--- a/src/main/java/com/intridea/io/vfs/operations/IMD5HashGetter.java
+++ b/src/main/java/com/intridea/io/vfs/operations/IMD5HashGetter.java
@@ -1,7 +1,7 @@
 package com.intridea.io.vfs.operations;
 
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.operations.FileOperation;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.operations.FileOperation;
 
 /**
  * Get md5 hash for file.

--- a/src/main/java/com/intridea/io/vfs/operations/IPublicUrlsGetter.java
+++ b/src/main/java/com/intridea/io/vfs/operations/IPublicUrlsGetter.java
@@ -1,7 +1,7 @@
 package com.intridea.io.vfs.operations;
 
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.operations.FileOperation;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.operations.FileOperation;
 
 /**
  * File operation for gettin' direct urls to S3 objects.

--- a/src/main/java/com/intridea/io/vfs/provider/s3/DepthFileSelector.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/DepthFileSelector.java
@@ -16,8 +16,8 @@
 
 package com.intridea.io.vfs.provider.s3;
 
-import org.apache.commons.vfs.FileSelectInfo;
-import org.apache.commons.vfs.FileSelector;
+import org.apache.commons.vfs2.FileSelectInfo;
+import org.apache.commons.vfs2.FileSelector;
 
 /**
  * A file selector that operates depth of the directory structure and will
@@ -57,11 +57,13 @@ public class DepthFileSelector implements FileSelector {
         maxDepth = max;
     }
 
+    @Override
     public boolean includeFile(FileSelectInfo fileSelectInfo) throws Exception {
         int depth = fileSelectInfo.getDepth();
         return depth >= minDepth && depth <= maxDepth;
     }
 
+    @Override
     public boolean traverseDescendents(FileSelectInfo fileSelectInfo)
             throws Exception {
         return fileSelectInfo.getDepth() < maxDepth;

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileName.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileName.java
@@ -16,8 +16,8 @@
 
 package com.intridea.io.vfs.provider.s3;
 
-import org.apache.commons.vfs.FileType;
-import org.apache.commons.vfs.provider.local.LocalFileName;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.provider.local.LocalFileName;
 
 public class S3FileName extends LocalFileName {
     protected S3FileName(final String scheme, final String rootFile, final String path, final FileType type) {

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileName.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileName.java
@@ -16,11 +16,33 @@
 
 package com.intridea.io.vfs.provider.s3;
 
+import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileType;
-import org.apache.commons.vfs2.provider.local.LocalFileName;
+import org.apache.commons.vfs2.provider.AbstractFileName;
 
-public class S3FileName extends LocalFileName {
-    protected S3FileName(final String scheme, final String rootFile, final String path, final FileType type) {
-        super(scheme, rootFile, path, type);
+public class S3FileName extends AbstractFileName {
+
+    private final String s3BucketId;
+
+    protected S3FileName(final String scheme, final String bucketId, final String path, final FileType type) {
+        super(scheme, path, type);
+        this.s3BucketId = bucketId;
+    }
+
+    public String getBucketId() {
+        return s3BucketId;
+    }
+
+
+    @Override
+    public FileName createName(String absPath, FileType type) {
+        return new S3FileName(getScheme(), s3BucketId, absPath, type);
+    }
+
+    @Override
+    protected void appendRootUri(StringBuilder buffer, boolean addPassword) {
+        buffer.append(getScheme());
+        buffer.append("://");
+        buffer.append(s3BucketId);
     }
 }

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileNameParser.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileNameParser.java
@@ -1,16 +1,17 @@
 package com.intridea.io.vfs.provider.s3;
 
-import org.apache.commons.vfs.FileName;
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.FileType;
-import org.apache.commons.vfs.provider.AbstractFileNameParser;
-import org.apache.commons.vfs.provider.UriParser;
-import org.apache.commons.vfs.provider.VfsComponentContext;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.provider.AbstractFileNameParser;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.apache.commons.vfs2.provider.VfsComponentContext;
 
 /**
  * @author Matthias L. Jugel
  */
 public class S3FileNameParser extends AbstractFileNameParser {
+
     /**
      * S3 file name parser instance
      */
@@ -30,10 +31,11 @@ public class S3FileNameParser extends AbstractFileNameParser {
     /**
      * Parses URI and constructs S3 file name.
      */
+    @Override
     public FileName parseUri(final VfsComponentContext context,
             final FileName base, final String filename)
             throws FileSystemException {
-        StringBuffer name = new StringBuffer();
+        StringBuilder name = new StringBuilder();
 
         String scheme = UriParser.extractScheme(filename, name);
         UriParser.canonicalizePath(name, 0, name.length(), this);

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileProvider.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileProvider.java
@@ -1,23 +1,23 @@
 package com.intridea.io.vfs.provider.s3;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.vfs.Capability;
-import org.apache.commons.vfs.FileName;
-import org.apache.commons.vfs.FileSystem;
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.FileSystemOptions;
-import org.apache.commons.vfs.provider.AbstractOriginatingFileProvider;
-import org.apache.commons.vfs.util.UserAuthenticatorUtils;
-import org.apache.commons.vfs.UserAuthenticationData;
+import org.apache.commons.vfs2.Capability;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.UserAuthenticationData;
+import org.apache.commons.vfs2.provider.AbstractOriginatingFileProvider;
+import org.apache.commons.vfs2.util.UserAuthenticatorUtils;
 import org.jets3t.service.S3Service;
 import org.jets3t.service.S3ServiceException;
 import org.jets3t.service.impl.rest.httpclient.RestS3Service;
 import org.jets3t.service.security.AWSCredentials;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 
 /**
  * An S3 file provider. Create an S3 file system out of an S3 file name. Also
@@ -87,6 +87,7 @@ public class S3FileProvider extends AbstractOriginatingFileProvider {
      * @return an S3 file system
      * @throws FileSystemException if the file system cannot be created
      */
+    @Override
     protected FileSystem doCreateFileSystem(FileName fileName,
             FileSystemOptions fileSystemOptions) throws FileSystemException {
 
@@ -133,6 +134,7 @@ public class S3FileProvider extends AbstractOriginatingFileProvider {
      *
      * @return the file system capabilities
      */
+    @Override
     public Collection<Capability> getCapabilities() {
         return capabilities;
     }

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystem.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystem.java
@@ -30,7 +30,7 @@ public class S3FileSystem extends AbstractFileSystem {
     public S3FileSystem(S3FileName fileName, S3Service service,
             FileSystemOptions fileSystemOptions) throws FileSystemException {
         super(fileName, null, fileSystemOptions);
-        String bucketId = fileName.getRootFile();
+        String bucketId = fileName.getBucketId();
         try {
             this.service = service;
             bucket = new S3Bucket(bucketId);

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystem.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystem.java
@@ -4,11 +4,12 @@ import java.util.Collection;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.vfs.FileName;
-import org.apache.commons.vfs.FileObject;
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.FileSystemOptions;
-import org.apache.commons.vfs.provider.AbstractFileSystem;
+import org.apache.commons.vfs2.Capability;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.provider.AbstractFileSystem;
 import org.jets3t.service.S3Service;
 import org.jets3t.service.ServiceException;
 import org.jets3t.service.model.S3Bucket;
@@ -20,6 +21,7 @@ import org.jets3t.service.model.S3Bucket;
  * @author Matthias L. Jugel
  */
 public class S3FileSystem extends AbstractFileSystem {
+
     private S3Service service;
     private S3Bucket bucket;
 
@@ -47,12 +49,14 @@ public class S3FileSystem extends AbstractFileSystem {
         }
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    protected void addCapabilities(Collection caps) {
+    @Override
+    protected void addCapabilities(Collection<Capability> caps) {
         caps.addAll(S3FileProvider.capabilities);
     }
 
-    protected FileObject createFile(FileName fileName) throws Exception {
+    @Override
+    protected FileObject createFile(AbstractFileName fileName) throws Exception {
         return new S3FileObject(fileName, this, service, bucket);
     }
+
 }

--- a/src/main/java/com/intridea/io/vfs/provider/s3/operations/AclGetter.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/operations/AclGetter.java
@@ -1,10 +1,10 @@
 package com.intridea.io.vfs.provider.s3.operations;
 
-import org.apache.commons.vfs.FileSystemException;
+import org.apache.commons.vfs2.FileSystemException;
 
 import com.intridea.io.vfs.operations.Acl;
-import com.intridea.io.vfs.operations.IAclGetter;
 import com.intridea.io.vfs.operations.Acl.Group;
+import com.intridea.io.vfs.operations.IAclGetter;
 import com.intridea.io.vfs.provider.s3.S3FileObject;
 
 class AclGetter implements IAclGetter {
@@ -17,18 +17,22 @@ class AclGetter implements IAclGetter {
         this.file = file;
     }
 
+    @Override
     public boolean canRead(Group group) {
         return acl.isAllowed(group, Acl.Permission.READ);
     }
 
+    @Override
     public boolean canWrite(Group group) {
         return acl.isAllowed(group, Acl.Permission.WRITE);
     }
 
+    @Override
     public Acl getAcl() {
         return acl;
     }
 
+    @Override
     public void process() throws FileSystemException {
         acl = file.getAcl();
     }

--- a/src/main/java/com/intridea/io/vfs/provider/s3/operations/AclSetter.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/operations/AclSetter.java
@@ -1,7 +1,7 @@
 package com.intridea.io.vfs.provider.s3.operations;
 
 
-import org.apache.commons.vfs.FileSystemException;
+import org.apache.commons.vfs2.FileSystemException;
 
 import com.intridea.io.vfs.operations.Acl;
 import com.intridea.io.vfs.operations.IAclSetter;
@@ -17,10 +17,12 @@ class AclSetter implements IAclSetter {
         this.file = file;
     }
 
+    @Override
     public void setAcl(Acl acl) {
         this.acl = acl;
     }
 
+    @Override
     public void process() throws FileSystemException {
         file.setAcl(acl);
     }

--- a/src/main/java/com/intridea/io/vfs/provider/s3/operations/MD5HashGetter.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/operations/MD5HashGetter.java
@@ -1,6 +1,6 @@
 package com.intridea.io.vfs.provider.s3.operations;
 
-import org.apache.commons.vfs.FileSystemException;
+import org.apache.commons.vfs2.FileSystemException;
 
 import com.intridea.io.vfs.operations.IMD5HashGetter;
 import com.intridea.io.vfs.provider.s3.S3FileObject;

--- a/src/main/java/com/intridea/io/vfs/provider/s3/operations/PublicUrlsGetter.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/operations/PublicUrlsGetter.java
@@ -1,6 +1,6 @@
 package com.intridea.io.vfs.provider.s3.operations;
 
-import org.apache.commons.vfs.FileSystemException;
+import org.apache.commons.vfs2.FileSystemException;
 
 import com.intridea.io.vfs.operations.IPublicUrlsGetter;
 import com.intridea.io.vfs.provider.s3.S3FileObject;

--- a/src/main/java/com/intridea/io/vfs/provider/s3/operations/S3FileOperationsProvider.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/operations/S3FileOperationsProvider.java
@@ -2,10 +2,10 @@ package com.intridea.io.vfs.provider.s3.operations;
 
 import java.util.Collection;
 
-import org.apache.commons.vfs.FileObject;
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.operations.FileOperation;
-import org.apache.commons.vfs.operations.FileOperationProvider;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.operations.FileOperation;
+import org.apache.commons.vfs2.operations.FileOperationProvider;
 
 import com.intridea.io.vfs.operations.IAclGetter;
 import com.intridea.io.vfs.operations.IAclSetter;
@@ -15,6 +15,7 @@ import com.intridea.io.vfs.provider.s3.S3FileObject;
 
 public class S3FileOperationsProvider implements FileOperationProvider {
 
+    @Override
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void collectOperations(Collection operationsList, FileObject file) throws FileSystemException {
         if (file instanceof S3FileObject) {
@@ -28,6 +29,7 @@ public class S3FileOperationsProvider implements FileOperationProvider {
     /**
      * Depending on operationClass return getter/setter for file access control list.
      */
+    @Override
     @SuppressWarnings("rawtypes")
     public FileOperation getOperation(FileObject file, Class operationClass) throws FileSystemException {
         if (file instanceof S3FileObject) {

--- a/src/main/java/com/scoyo/commons/vfs/S3Util.java
+++ b/src/main/java/com/scoyo/commons/vfs/S3Util.java
@@ -6,10 +6,10 @@ import java.util.Properties;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.FileSystemOptions;
-import org.apache.commons.vfs.auth.StaticUserAuthenticator;
-import org.apache.commons.vfs.impl.DefaultFileSystemConfigBuilder;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.auth.StaticUserAuthenticator;
+import org.apache.commons.vfs2.impl.DefaultFileSystemConfigBuilder;
 
 import com.intridea.io.vfs.provider.s3.S3FileProvider;
 

--- a/src/test/java/com/intridea/io/vfs/TestEnvironment.java
+++ b/src/test/java/com/intridea/io/vfs/TestEnvironment.java
@@ -5,9 +5,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.apache.commons.vfs.FileSystemOptions;
-import org.apache.commons.vfs.auth.StaticUserAuthenticator;
-import org.apache.commons.vfs.impl.DefaultFileSystemConfigBuilder;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.auth.StaticUserAuthenticator;
+import org.apache.commons.vfs2.impl.DefaultFileSystemConfigBuilder;
 import org.testng.Assert;
 
 import com.intridea.io.vfs.provider.s3.S3FileProvider;

--- a/src/test/java/com/intridea/io/vfs/provider/s3/S3ProviderTest.java
+++ b/src/test/java/com/intridea/io/vfs/provider/s3/S3ProviderTest.java
@@ -1,5 +1,8 @@
 package com.intridea.io.vfs.provider.s3;
 
+import static org.jets3t.service.utils.ServiceUtils.computeMD5Hash;
+import static org.jets3t.service.utils.ServiceUtils.toHex;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -10,15 +13,13 @@ import java.util.Properties;
 import java.util.Random;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.vfs.FileObject;
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.FileSystemManager;
-import org.apache.commons.vfs.FileSystemOptions;
-import org.apache.commons.vfs.FileType;
-import org.apache.commons.vfs.Selectors;
-import org.apache.commons.vfs.VFS;
-import static org.jets3t.service.utils.ServiceUtils.*;
-
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.VFS;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -27,6 +28,7 @@ import org.testng.annotations.Test;
 import com.intridea.io.vfs.TestEnvironment;
 import com.intridea.io.vfs.operations.IMD5HashGetter;
 import com.intridea.io.vfs.operations.IPublicUrlsGetter;
+
 
 @Test(groups={"storage"})
 public class S3ProviderTest {

--- a/src/test/java/com/intridea/io/vfs/provider/s3/acl/PackageTest.java
+++ b/src/test/java/com/intridea/io/vfs/provider/s3/acl/PackageTest.java
@@ -4,20 +4,19 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
 
-import com.intridea.io.vfs.TestEnvironment;
-import com.intridea.io.vfs.operations.Acl;
-import com.intridea.io.vfs.operations.IAclGetter;
-import com.intridea.io.vfs.operations.IAclSetter;
-
-import org.apache.commons.vfs.FileObject;
-import org.apache.commons.vfs.FileSystemException;
-import org.apache.commons.vfs.FileSystemManager;
-import org.apache.commons.vfs.VFS;
-
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import com.intridea.io.vfs.TestEnvironment;
+import com.intridea.io.vfs.operations.Acl;
+import com.intridea.io.vfs.operations.IAclGetter;
+import com.intridea.io.vfs.operations.IAclSetter;
 
 @Test(groups={"storage", "acl"})
 public class PackageTest {


### PR DESCRIPTION
I switched the vfs-s3 implementation to Apache VFS 2.0 which was released in August.

I removed the SNAPSHOT dependency to JetS3t, just because I hadn't the snapshot available in any repository. The multiple-upload-test does fail therefore, but the other tests are just fine (we will have to do something about the big file test too, because there is no iso available).
