### PR TITLE
Bug Fixes and Optimizations

### DIFF
--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileObject.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileObject.java
@@ -227,34 +227,40 @@ public class S3FileObject extends AbstractFileObject {
 
     @Override
     protected String[] doListChildren() throws Exception {
-        String path = objectKey;
+       String path = objectKey;
         // make sure we add a '/' slash at the end to find children
         if ((!"".equals(path)) && (!path.endsWith(SEPARATOR))) {
             path = path + "/";
         }
 
-        ObjectListing listing = service.listObjects(bucket.getName(), path);
-        final List<S3ObjectSummary> summaries = new ArrayList<S3ObjectSummary>(listing.getObjectSummaries());
-        while (listing.isTruncated()) {
-            final ListObjectsRequest loReq = new ListObjectsRequest();
-            loReq.setBucketName(bucket.getName());
-            loReq.setMarker(listing.getNextMarker());
-            listing = service.listObjects(loReq);
-            summaries.addAll(listing.getObjectSummaries());
-        }
+		final ListObjectsRequest loReq = new ListObjectsRequest();
+		loReq.setBucketName(bucket.getName());
+		loReq.setDelimiter("/");
+		loReq.setPrefix(path);
 
-        List<String> childrenNames = new ArrayList<String>(summaries.size());
+		ObjectListing listing = service.listObjects(loReq);
+		final List<S3ObjectSummary> summaries = new ArrayList<S3ObjectSummary>(listing.getObjectSummaries());
+		final Set<String> commonPrefixes = new TreeSet<>(listing.getCommonPrefixes());
+		while (listing.isTruncated()) {
+			listing = service.listNextBatchOfObjects(listing);
+			summaries.addAll(listing.getObjectSummaries());
+			commonPrefixes.addAll(listing.getCommonPrefixes());
+		}
+
+        List<String> childrenNames = new ArrayList<String>(summaries.size() + commonPrefixes.size());
+
+		// add the prefixes (non-empty subdirs) first
+		for (String commonPrefix : commonPrefixes) {
+			// strip path from name (leave only base name)
+			final String stripPath = commonPrefix.substring(path.length());
+			childrenNames.add(stripPath);
+		}
 
         for (S3ObjectSummary summary : summaries) {
             if (!summary.getKey().equals(path)) {
                 // strip path from name (leave only base name)
                 final String stripPath = summary.getKey().substring(path.length());
-
-                // Only one slash in the end OR no slash at all
-                if ((stripPath.endsWith(SEPARATOR) && (stripPath.indexOf(SEPARATOR_CHAR) == stripPath.lastIndexOf(SEPARATOR_CHAR))) ||
-                        (stripPath.indexOf(SEPARATOR_CHAR) == (-1))) {
-                    childrenNames.add(stripPath);
-                }
+                childrenNames.add(stripPath);
             }
         }
 
@@ -280,40 +286,50 @@ public class S3FileObject extends AbstractFileObject {
 			path = path + "/";
 		}
 
-		ObjectListing listing = service.listObjects(bucket.getName(), path);
+		final ListObjectsRequest loReq = new ListObjectsRequest();
+		loReq.setBucketName(bucket.getName());
+		loReq.setDelimiter("/");
+		loReq.setPrefix(path);
+
+		ObjectListing listing = service.listObjects(loReq);
 		final List<S3ObjectSummary> summaries = new ArrayList<S3ObjectSummary>(listing.getObjectSummaries());
+		final Set<String> commonPrefixes = new TreeSet<>(listing.getCommonPrefixes());
 		while (listing.isTruncated()) {
-			final ListObjectsRequest loReq = new ListObjectsRequest();
-			loReq.setBucketName(bucket.getName());
-			loReq.setMarker(listing.getNextMarker());
-			listing = service.listObjects(loReq);
+			listing = service.listNextBatchOfObjects(listing);
 			summaries.addAll(listing.getObjectSummaries());
+			commonPrefixes.addAll(listing.getCommonPrefixes());
 		}
 
-		List<FileObject> resolvedChildren = new ArrayList<FileObject>(summaries.size());
+		List<FileObject> resolvedChildren = new ArrayList<FileObject>(summaries.size() + commonPrefixes.size());
+
+		// add the prefixes (non-empty subdirs) first
+		for (String commonPrefix : commonPrefixes) {
+			// strip path from name (leave only base name)
+			final String stripPath = commonPrefix.substring(path.length());
+			FileObject childObject = resolveFile(stripPath, NameScope.CHILD);
+			if (childObject instanceof S3FileObject) {
+				S3FileObject s3FileObject = (S3FileObject)childObject;
+				resolvedChildren.add(s3FileObject);
+			}
+		}
 
 		for (S3ObjectSummary summary : summaries) {
 			if (!summary.getKey().equals(path)) {
 				// strip path from name (leave only base name)
 				final String stripPath = summary.getKey().substring(path.length());
-
-				// Only one slash in the end OR no slash at all
-				if ((stripPath.endsWith(SEPARATOR) && (stripPath.indexOf(SEPARATOR_CHAR) == stripPath.lastIndexOf(SEPARATOR_CHAR))) ||
-					(stripPath.indexOf(SEPARATOR_CHAR) == (-1))) {
-					FileObject childObject = resolveFile(stripPath, NameScope.CHILD);
-					if (childObject instanceof S3FileObject) {
-						S3FileObject s3FileObject = (S3FileObject)childObject;
-						ObjectMetadata childMetadata = new ObjectMetadata();
-						childMetadata.setContentLength(summary.getSize());
-						childMetadata.setContentType(
-							Mimetypes.getInstance().getMimetype(s3FileObject.getName().getBaseName()));
-						childMetadata.setLastModified(summary.getLastModified());
-						childMetadata.setHeader(Headers.ETAG, summary.getETag());
-						s3FileObject.objectMetadata = childMetadata;
-						s3FileObject.objectKey = summary.getKey();
-						s3FileObject.attached = true;
-						resolvedChildren.add(s3FileObject);
-					}
+				FileObject childObject = resolveFile(stripPath, NameScope.CHILD);
+				if (childObject instanceof S3FileObject) {
+					S3FileObject s3FileObject = (S3FileObject)childObject;
+					ObjectMetadata childMetadata = new ObjectMetadata();
+					childMetadata.setContentLength(summary.getSize());
+					childMetadata.setContentType(
+						Mimetypes.getInstance().getMimetype(s3FileObject.getName().getBaseName()));
+					childMetadata.setLastModified(summary.getLastModified());
+					childMetadata.setHeader(Headers.ETAG, summary.getETag());
+					s3FileObject.objectMetadata = childMetadata;
+					s3FileObject.objectKey = summary.getKey();
+					s3FileObject.attached = true;
+					resolvedChildren.add(s3FileObject);
 				}
 			}
 		}

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystem.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystem.java
@@ -75,4 +75,12 @@ public class S3FileSystem extends AbstractFileSystem {
     protected FileObject createFile(AbstractFileName fileName) throws Exception {
         return new S3FileObject(fileName, this, awsCredentials, service, transferManager, bucket);
     }
+
+	@Override
+	protected void doCloseCommunicationLink()
+	{
+		if (transferManager != null) {
+			transferManager.shutdownNow();
+		}
+	}
 }


### PR DESCRIPTION
Implemented S3FileSystem.doCloseCommunicationLink() so that transferManager gets cleaned up and doesn't leave worker threads running.

Fixed doListChildren() and doListChildrenResolved() to not choke when the initialize list is truncated because subsequent requests did not set the prefix.

Improved efficiency of doListChildren() and doListChildrenResolved() by using delimiter in addition to prefix to limit the response to only immediate children instead of post-filtering the response.
