### PR TITLE
Improve reliability of large file uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@ target/
 *.iws
 /test-output
 .idea
+src/test/resources/commons-logging.properties
+src/test/.DS_Store
 .envrc
 atlassian-ide-plugin.xml

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileProvider.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileProvider.java
@@ -3,9 +3,8 @@ package com.intridea.io.vfs.provider.s3;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.regions.Regions;
+import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.Region;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.*;
@@ -58,7 +57,7 @@ public class S3FileProvider extends AbstractOriginatingFileProvider {
     /**
      * Returns default S3 file system options.
      * Use it to set AWS auth credentials.
-     * @return
+     * @return default S3 file system options
      */
     public static FileSystemOptions getDefaultFileSystemOptions () {
         return defaultOptions;
@@ -136,10 +135,10 @@ public class S3FileProvider extends AbstractOriginatingFileProvider {
     /**
      * Check for empty string FIXME find the same at Amazon SDK
      *
-     * @param s
-     * @return
+     * @param s string
+     * @return true iff string is null or zero length
      */
-    private final boolean isEmpty(String s) {
+    private boolean isEmpty(String s) {
         return ((s == null) || (s.length() == 0));
     }
 }

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystem.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystem.java
@@ -16,7 +16,6 @@ import org.apache.commons.vfs2.provider.AbstractFileSystem;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.transfer.TransferManager;
 
 /**
  * An S3 file system.
@@ -30,7 +29,6 @@ public class S3FileSystem extends AbstractFileSystem {
     private static final Log logger = LogFactory.getLog(S3FileSystem.class);
 
     private final AmazonS3Client service;
-    private final TransferManager transferManager;
     private final Bucket bucket;
     private final AWSCredentials awsCredentials;
 
@@ -45,7 +43,6 @@ public class S3FileSystem extends AbstractFileSystem {
 
         this.awsCredentials = awsCredentials;
         this.service = service;
-        this.transferManager = new TransferManager(service);
         this.serverSideEncryption = S3FileSystemConfigBuilder
             .getInstance().getServerSideEncryption(fileSystemOptions);
 
@@ -81,7 +78,6 @@ public class S3FileSystem extends AbstractFileSystem {
     }
 
     public void shutdown() {
-        getTransferManager().shutdownNow();
         getService().shutdown();
     }
 
@@ -109,20 +105,13 @@ public class S3FileSystem extends AbstractFileSystem {
         return service;
     }
 
-    protected TransferManager getTransferManager() {
-        return transferManager;
-    }
-
     @Override
     protected FileObject createFile(AbstractFileName fileName) throws Exception {
         return new S3FileObject(fileName, this);
     }
-    
+
     @Override
     protected void doCloseCommunicationLink()
     {
-        if (transferManager != null) {
-            transferManager.shutdownNow();
-        }
     }
 }

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystemConfigBuilder.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystemConfigBuilder.java
@@ -8,10 +8,13 @@ import org.apache.commons.vfs2.FileSystemOptions;
 
 public class S3FileSystemConfigBuilder extends FileSystemConfigBuilder {
     private static final S3FileSystemConfigBuilder BUILDER = new S3FileSystemConfigBuilder();
-    
+
     private static final String SERVER_SIDE_ENCRYPTION = S3FileSystemConfigBuilder.class.getName() + ".SERVER_SIDE_ENCRYPTION";
     private static final String REGION = S3FileSystemConfigBuilder.class.getName() + ".REGION";
     private static final String CLIENT_CONFIGURATION = S3FileSystemConfigBuilder.class.getName() + ".CLIENT_CONFIGURATION";
+    private static final String MAX_UPLOAD_THREADS = S3FileSystemConfigBuilder.class.getName() + ".MAX_UPLOAD_THREADS";
+
+    public static final int DEFAULT_MAX_UPLOAD_THREADS = 2;
 
     private S3FileSystemConfigBuilder()
     {
@@ -93,4 +96,23 @@ public class S3FileSystemConfigBuilder extends FileSystemConfigBuilder {
         }
         return clientConfiguration;
     }
+
+    /**
+     * Set maximum number of threads to use for a single large (16MB or more) upload
+     * @param opts The FileSystemOptions
+     * @param maxRetries maximum number of threads to use for a single large (16MB or more) upload
+     */
+    public void setMaxUploadThreads(FileSystemOptions opts, int maxRetries) {
+        setParam(opts, MAX_UPLOAD_THREADS, maxRetries);
+    }
+
+    /**
+     * Get maximum number of threads to use for a single large (16MB or more) upload
+     * @param opts The FileSystemOptions
+     * @return maximum number of threads to use for a single large (16MB or more) upload
+     */
+    public int getMaxUploadThreads(FileSystemOptions opts) {
+        return getInteger(opts, MAX_UPLOAD_THREADS, DEFAULT_MAX_UPLOAD_THREADS);
+    }
+
 }


### PR DESCRIPTION
1. Only use TransferManager for files larger than the multi-part threshold (16MB).
2. Create and destroy TransferManager for each uploaded large file since relative overhead is very small and and some usage patterns are causing the thread pool to get leaked.
3. Always upload from File object since that is the only case where the upload will be retried automatically by the AWS SDK.
4. Allow configuration of maximum number of upload parallel threads since the default of 10 performs very poorly and seems to cause lots of errors, and can saturate network upload bandwidth.
