### PR TITLE
Fix support of DelegatingFileSystemOptionsBuilder

### DIFF
--- a/src/main/java/com/github/vfss3/S3FileProvider.java
+++ b/src/main/java/com/github/vfss3/S3FileProvider.java
@@ -28,6 +28,11 @@ import static com.amazonaws.regions.Regions.DEFAULT_REGION;
  * @author Moritz Siuts
  */
 public class S3FileProvider extends AbstractOriginatingFileProvider {
+    /**
+     * Supported schema
+     */
+    public static final String SCHEMA = "s3";
+
     public final static Collection<Capability> capabilities = Collections.unmodifiableCollection(Arrays.asList(
         Capability.CREATE,
         Capability.DELETE,

--- a/src/main/java/com/github/vfss3/S3FileProvider.java
+++ b/src/main/java/com/github/vfss3/S3FileProvider.java
@@ -29,9 +29,9 @@ import static com.amazonaws.regions.Regions.DEFAULT_REGION;
  */
 public class S3FileProvider extends AbstractOriginatingFileProvider {
     /**
-     * Supported schema
+     * Protocol prefix
      */
-    public static final String SCHEMA = "s3";
+    public static final String PREFIX = "s3";
 
     public final static Collection<Capability> capabilities = Collections.unmodifiableCollection(Arrays.asList(
         Capability.CREATE,

--- a/src/main/java/com/github/vfss3/S3FileSystemConfigBuilder.java
+++ b/src/main/java/com/github/vfss3/S3FileSystemConfigBuilder.java
@@ -42,7 +42,7 @@ public class S3FileSystemConfigBuilder extends FileSystemConfigBuilder {
     }
 
     private S3FileSystemConfigBuilder() {
-        super("s3.");
+        super(S3FileProvider.PREFIX + ".");
     }
 
     @Override

--- a/src/main/java/com/github/vfss3/S3FileSystemConfigBuilder.java
+++ b/src/main/java/com/github/vfss3/S3FileSystemConfigBuilder.java
@@ -10,7 +10,6 @@ import org.apache.commons.vfs2.FileSystemOptions;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -177,7 +176,7 @@ public class S3FileSystemConfigBuilder extends FileSystemConfigBuilder {
         if (getRegion(opts).isPresent()) {
             throw new IllegalArgumentException("Cannot set both Region and Endpoint");
         }
-        setOption(opts, ENDPOINT, requireNonNull(endpoint) );
+        setOption(opts, ENDPOINT, requireNonNull(endpoint));
     }
 
     /**

--- a/src/main/java/com/github/vfss3/S3FileSystemConfigBuilder.java
+++ b/src/main/java/com/github/vfss3/S3FileSystemConfigBuilder.java
@@ -80,24 +80,26 @@ public class S3FileSystemConfigBuilder extends FileSystemConfigBuilder {
     }
 
     /**
-     * Set default region for S3 client
+     * Set default region for S3 client. Region is a string which can be recognized by the method
+     * {@link Regions#fromName(java.lang.String)}. The class {@link Regions} cannot be used as a parameter of this setter
+     * because the current version of commons-vfs uses only {@link Enum#valueOf(java.lang.Class, java.lang.String)} to parse enum.
      *
-     * @param region The S3 region to connect to (if null, then US Standard)
+     * @param region The S3 region to connect to
      */
-    public void setRegion(final FileSystemOptions opts, Regions region) {
+    public void setRegion(final FileSystemOptions opts, String region) {
         if (getEndpoint(opts).isPresent()) {
             throw new IllegalArgumentException("Cannot set both Region and Endpoint");
         }
-        setOption(opts, REGION, requireNonNull(region).toString());
+        setOption(opts, REGION, requireNonNull(region));
     }
 
     /**
-     * @return The S3 region to connect to (if null, then US Standard)
+     * @return The S3 region to connect to
      */
-    public Optional<Regions> getRegion(final FileSystemOptions opts) {
+    public Optional<String> getRegion(final FileSystemOptions opts) {
         String r = getStringOption(opts, REGION, null);
 
-        return (r == null) ? empty() : Optional.of(Regions.fromName(r));
+        return ofNullable(r);
     }
 
     /**
@@ -175,7 +177,7 @@ public class S3FileSystemConfigBuilder extends FileSystemConfigBuilder {
         if (getRegion(opts).isPresent()) {
             throw new IllegalArgumentException("Cannot set both Region and Endpoint");
         }
-        setOption(opts, ENDPOINT, requireNonNull(endpoint));
+        setOption(opts, ENDPOINT, requireNonNull(endpoint) );
     }
 
     /**

--- a/src/main/java/com/github/vfss3/S3FileSystemOptions.java
+++ b/src/main/java/com/github/vfss3/S3FileSystemOptions.java
@@ -64,17 +64,23 @@ public class S3FileSystemOptions {
     /**
      * Set default region for S3 client
      *
-     * @param region The S3 region to connect to (if null, then US Standard)
+     * @param region The S3 region to connect to
      */
     public void setRegion(Regions region) {
-        S3FileSystemConfigBuilder.getInstance().setRegion(options, region);
+        if (region == null) {
+            throw new IllegalArgumentException("AWS Region cannot be null");
+        }
+
+        S3FileSystemConfigBuilder.getInstance().setRegion(options, region.getName());
     }
 
     /**
-     * @return The S3 region to connect to (if null, then US Standard)
+     * @return The S3 region to connect to
      */
     public Optional<Regions> getRegion() {
-        return S3FileSystemConfigBuilder.getInstance().getRegion(options);
+        Optional<String> r = S3FileSystemConfigBuilder.getInstance().getRegion(options);
+
+        return r.map(Regions::fromName);
     }
 
     /**

--- a/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystemConfigBuilder.java
+++ b/src/main/java/com/intridea/io/vfs/provider/s3/S3FileSystemConfigBuilder.java
@@ -4,7 +4,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.Region;
+import com.github.vfss3.S3FileProvider;
 import com.github.vfss3.S3FileSystemOptions;
 import org.apache.commons.vfs2.FileSystem;
 import org.apache.commons.vfs2.FileSystemConfigBuilder;
@@ -18,9 +18,8 @@ import org.apache.commons.vfs2.FileSystemOptions;
 public class S3FileSystemConfigBuilder extends FileSystemConfigBuilder {
     private static final S3FileSystemConfigBuilder BUILDER = new S3FileSystemConfigBuilder();
 
-    private S3FileSystemConfigBuilder()
-    {
-        super("s3.");
+    private S3FileSystemConfigBuilder() {
+        super(S3FileProvider.PREFIX + ".");
     }
 
     public static S3FileSystemConfigBuilder getInstance()

--- a/src/test/java/com/github/vfss3/S3FileSystemOptionsTest.java
+++ b/src/test/java/com/github/vfss3/S3FileSystemOptionsTest.java
@@ -1,0 +1,36 @@
+package com.github.vfss3;
+
+import com.amazonaws.regions.Regions;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.*;
+
+/**
+ * Unit tests for {@link com.github.vfss3.S3FileSystemOptions}
+ */
+public class S3FileSystemOptionsTest {
+
+    @Test
+    public void testWriteReadRegion() {
+        S3FileSystemOptions options = new S3FileSystemOptions();
+
+        Regions expectedValue = Regions.DEFAULT_REGION;
+        options.setRegion(expectedValue);
+        Optional<Regions> actual = options.getRegion();
+
+        assertNotNull(actual, "Region object cannot be null");
+        assertTrue(actual.isPresent(), "Region cannot be null");
+        assertEquals(actual.get(), expectedValue);
+    }
+
+    @Test
+    public void testRegion() {
+        S3FileSystemOptions options = new S3FileSystemOptions();
+        Optional<Regions> region = options.getRegion();
+
+        assertNotNull(region, "Region object cannot be null");
+        assertFalse(region.isPresent(), "Region value should be empty");
+    }
+}

--- a/src/test/java/com/github/vfss3/VfsS3Test.java
+++ b/src/test/java/com/github/vfss3/VfsS3Test.java
@@ -1,10 +1,11 @@
 package com.github.vfss3;
 
-import org.apache.commons.vfs2.FileSystemManager;
-import org.apache.commons.vfs2.FileSystemOptions;
-import org.apache.commons.vfs2.VFS;
+import com.amazonaws.regions.Regions;
+import org.apache.commons.vfs2.*;
 import org.apache.commons.vfs2.util.DelegatingFileSystemOptionsBuilder;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
 
 /**
  * Unit test for vfs-s3
@@ -18,5 +19,17 @@ public class VfsS3Test {
         DelegatingFileSystemOptionsBuilder builder = new DelegatingFileSystemOptionsBuilder(manager);
         builder.setConfigString(options, "s3", "serverSideEncryption", "true");
         options.clone();
+    }
+
+    @Test(description = "Test how VFS-S3 plugin can access public OSM bucket, see https://registry.opendata.aws/osm/")
+    public void testResolvePublicBucket() throws FileSystemException {
+        FileSystemManager manager = VFS.getManager();
+        FileSystemOptions options = new FileSystemOptions();
+        DelegatingFileSystemOptionsBuilder builder = new DelegatingFileSystemOptionsBuilder(manager);
+        builder.setConfigString(options, "s3", "region", Regions.US_EAST_1.getName());
+        String bucket = "s3://osm-pds";
+        FileObject file = manager.resolveFile(bucket, options);
+
+        assertNotNull(file, "Public bucket " + bucket + " is not resolved");
     }
 }

--- a/src/test/java/com/github/vfss3/VfsS3Test.java
+++ b/src/test/java/com/github/vfss3/VfsS3Test.java
@@ -17,7 +17,7 @@ public class VfsS3Test {
         FileSystemManager manager = VFS.getManager();
         FileSystemOptions options = new FileSystemOptions();
         DelegatingFileSystemOptionsBuilder builder = new DelegatingFileSystemOptionsBuilder(manager);
-        builder.setConfigString(options, "s3", "serverSideEncryption", "true");
+        builder.setConfigString(options, S3FileProvider.PREFIX, "serverSideEncryption", "true");
         options.clone();
     }
 
@@ -26,7 +26,7 @@ public class VfsS3Test {
         FileSystemManager manager = VFS.getManager();
         FileSystemOptions options = new FileSystemOptions();
         DelegatingFileSystemOptionsBuilder builder = new DelegatingFileSystemOptionsBuilder(manager);
-        builder.setConfigString(options, S3FileProvider.SCHEMA, "region", Regions.US_EAST_1.getName());
+        builder.setConfigString(options, S3FileProvider.PREFIX, "region", Regions.US_EAST_1.getName());
         String bucket = "s3://osm-pds";
         FileObject file = manager.resolveFile(bucket, options);
 

--- a/src/test/java/com/github/vfss3/VfsS3Test.java
+++ b/src/test/java/com/github/vfss3/VfsS3Test.java
@@ -26,7 +26,7 @@ public class VfsS3Test {
         FileSystemManager manager = VFS.getManager();
         FileSystemOptions options = new FileSystemOptions();
         DelegatingFileSystemOptionsBuilder builder = new DelegatingFileSystemOptionsBuilder(manager);
-        builder.setConfigString(options, "s3", "region", Regions.US_EAST_1.getName());
+        builder.setConfigString(options, S3FileProvider.SCHEMA, "region", Regions.US_EAST_1.getName());
         String bucket = "s3://osm-pds";
         FileObject file = manager.resolveFile(bucket, options);
 


### PR DESCRIPTION
Fix support of DelegatingFileSystemOptionsBuilder (commons-vfs). Add unit tests to prevent such regression issues in the future.

Note: this fix is required to provide compatibility with the previous versions of the vfs-s3. Here is the sample code which works with the 2.X version of the vfs-s3
```
        FileSystemManager manager = VFS.getManager();
        FileSystemOptions options = new FileSystemOptions();
        DelegatingFileSystemOptionsBuilder builder = new DelegatingFileSystemOptionsBuilder(manager);
        builder.setConfigString(options, "s3", "region", "us-east-1");

```