### PR TITLE
Fix not being able to open new streams after closing an `S3FileObject`

### DIFF
--- a/src/main/java/com/github/vfss3/S3FileObject.java
+++ b/src/main/java/com/github/vfss3/S3FileObject.java
@@ -344,6 +344,7 @@ public class S3FileObject extends AbstractFileObject<S3FileSystem> {
 
         if (objectContentHolder != null) {
             objectContentHolder.close();
+            objectContentHolder = null;
         }
     }
 


### PR DESCRIPTION
Because in `doGetInputStream` and `doGetOutputStream` `objectContentHolder` is checked against `null` and only initialized if it is. So on `close` we set it to `null` and hopefully that will allow us to open new streams after the file-object has been closed.

cc @abashev 