### PR TITLE
Check 'isCreateBucket' after determining the bucket does not exist

### DIFF
--- a/src/main/java/com/github/vfss3/S3FileSystem.java
+++ b/src/main/java/com/github/vfss3/S3FileSystem.java
@@ -44,7 +44,7 @@ public class S3FileSystem extends AbstractFileSystem {
         }
 
         try {
-            if (options.isCreateBucket() && !doesBucketExist(rootName.getBucket())) {
+            if (!doesBucketExist(rootName.getBucket()) && options.isCreateBucket()) {
                 CreateBucketRequest createBucketRequest = new CreateBucketRequest(rootName.getBucket());
 
                 ofNullable(options.getObjectOwnership()).ifPresent(createBucketRequest::setObjectOwnership);


### PR DESCRIPTION
I was experiencing the problem described by #76.  This change aims to provide a simple solution:

> Swap the order of the AND statement  so that `doesBucketExist` is invoked when `createBucket=false`.  

Tests are passing with this change. 