### PR TITLE
Configure JReleaser Maven Central releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,5 @@
 // Module-specific build logic lives in each subproject's build.gradle.
 
 plugins {
-    alias(libs.plugins.nexus.publish)
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl = uri('https://oss.sonatype.org/service/local/')
-            snapshotRepositoryUrl = uri('https://oss.sonatype.org/content/repositories/snapshots/')
-        }
-    }
+    id 'vfs-s3.release-conventions'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -6,9 +6,14 @@ repositories {
     gradlePluginPortal()
 }
 
+configurations.configureEach {
+    resolutionStrategy.force 'org.eclipse.jgit:org.eclipse.jgit:5.13.5.202508271544-r'
+}
+
 dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:8.4.0'
     implementation 'net.ltgt.gradle:gradle-errorprone-plugin:4.4.0'
     implementation 'net.ltgt.gradle:gradle-nullaway-plugin:3.0.0'
     implementation 'io.freefair.gradle:lombok-plugin:9.5.0'
+    implementation 'org.jreleaser:org.jreleaser.gradle.plugin:1.24.0'
 }

--- a/buildSrc/src/main/groovy/vfs-s3.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/vfs-s3.publishing-conventions.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id 'maven-publish'
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            pom {
+                name.set(project.provider { "${project.group}:${project.name}" })
+                description.set(project.provider { project.description ?: project.name })
+                url = 'https://github.com/abashev/vfs-s3'
+                licenses {
+                    license {
+                        name = 'The Apache Software License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
+                    }
+                }
+                developers {
+                    developer {
+                        name = 'Alexey Abashev'
+                        email = 'alexey@abashev.ru'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/abashev/vfs-s3.git'
+                    developerConnection = 'scm:git:ssh://github.com:abashev/vfs-s3.git'
+                    url = 'https://github.com/abashev/vfs-s3'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = 'staging'
+            url = layout.buildDirectory.dir('staging-deploy')
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/vfs-s3.release-conventions.gradle
+++ b/buildSrc/src/main/groovy/vfs-s3.release-conventions.gradle
@@ -1,0 +1,62 @@
+plugins {
+    id 'base'
+    id 'org.jreleaser'
+}
+
+jreleaser {
+    dependsOnAssemble = false
+
+    project {
+        name = 'vfs-s3'
+        description = 'S3 virtual file system for Java'
+        license = 'Apache-2.0'
+        links {
+            homepage = 'https://github.com/abashev/vfs-s3'
+        }
+        languages {
+            java {
+                groupId = 'com.github.abashev'
+                multiProject = true
+                version = '17'
+            }
+        }
+    }
+
+    release {
+        github {
+            enabled = false
+        }
+    }
+
+    signing {
+        pgp {
+            active = 'ALWAYS'
+            armored = true
+            verify = false
+        }
+    }
+
+    deploy {
+        maven {
+            mavenCentral {
+                sonatype {
+                    active = 'ALWAYS'
+                    url = 'https://central.sonatype.com/api/v1/publisher'
+                    namespace = 'com.github.abashev'
+                    applyMavenCentralRules = true
+                    stagingRepository('modules/commons-vfs/build/staging-deploy')
+                    stagingRepository('modules/jdk/build/staging-deploy')
+                    stagingRepository('modules/spring-6/build/staging-deploy')
+                    stagingRepository('modules/spring-7/build/staging-deploy')
+                }
+            }
+        }
+    }
+}
+
+tasks.named('jreleaserDeploy') {
+    dependsOn ':modules:commons-vfs:publishAllPublicationsToStagingRepository'
+    dependsOn ':modules:jdk:publishAllPublicationsToStagingRepository'
+    dependsOn ':modules:spring-6:publishAllPublicationsToStagingRepository'
+    dependsOn ':modules:spring-7:publishAllPublicationsToStagingRepository'
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,3 @@ spring-core = { module = "org.springframework:spring-core", version.ref = "sprin
 spring-context = { module = "org.springframework:spring-context", version.ref = "spring" }
 spring7-core = { module = "org.springframework:spring-core", version.ref = "spring7" }
 spring7-context = { module = "org.springframework:spring-context", version.ref = "spring7" }
-
-[plugins]
-nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }

--- a/mise.toml
+++ b/mise.toml
@@ -8,3 +8,7 @@ run = "./gradlew spotlessApply"
 [tasks."format.check"]
 description = "Check Java formatting (fails if unformatted)"
 run = "./gradlew spotlessCheck"
+
+[tasks.release]
+description = "Stage, sign, and publish the release to Maven Central with JReleaser"
+run = "./gradlew clean jreleaserDeploy"

--- a/modules/commons-vfs/build.gradle
+++ b/modules/commons-vfs/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id 'vfs-s3.java-conventions'
-
-    id 'maven-publish'
-    id 'signing'
+    id 'vfs-s3.publishing-conventions'
 }
 
 description = 'Amazon S3 driver for VFS (Apache Commons Virtual File System)'
@@ -54,45 +52,4 @@ tasks.named('integrationTest', Test) {
     if (!providers.environmentVariable('BASE_URL').isPresent()) {
         exclude '**/remote/EnvironmentBasedSuite.class'
     }
-}
-
-// Maven publishing
-java {
-    withSourcesJar()
-    withJavadocJar()
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-            pom {
-                name = "${project.group}:${project.name}"
-                description = project.description
-                url = 'https://github.com/abashev/vfs-s3'
-                licenses {
-                    license {
-                        name = 'The Apache Software License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution = 'repo'
-                    }
-                }
-                developers {
-                    developer {
-                        name = 'Alexey Abashev'
-                        email = 'alexey@abashev.ru'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/abashev/vfs-s3.git'
-                    developerConnection = 'scm:git:ssh://github.com:abashev/vfs-s3.git'
-                    url = 'https://github.com/abashev/vfs-s3'
-                }
-            }
-        }
-    }
-}
-
-signing {
-    sign publishing.publications.mavenJava
 }

--- a/modules/jdk/build.gradle
+++ b/modules/jdk/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'vfs-s3.java-conventions'
+    id 'vfs-s3.publishing-conventions'
 }
 
 description = 'Amazon S3 FileSystemProvider for JDK NIO.2 (java.nio.file.spi.FileSystemProvider)'

--- a/modules/spring-6/build.gradle
+++ b/modules/spring-6/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'vfs-s3.java-conventions'
+    id 'vfs-s3.publishing-conventions'
 }
 
 description = 'Amazon S3 Spring 6 Resource / ResourceLoader implementation'

--- a/modules/spring-7/build.gradle
+++ b/modules/spring-7/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'vfs-s3.java-conventions'
+    id 'vfs-s3.publishing-conventions'
 }
 
 description = 'Amazon S3 Spring 7 Resource / ResourceLoader implementation'


### PR DESCRIPTION
## Summary
- Add release and publishing Gradle convention plugins for JReleaser-based Maven Central releases
- Publish all current modules to local staging repositories before JReleaser deploys
- Add a mise release task for the single Gradle release command

## Validation
- Not run in this PR step per request; release deploy is currently running locally.