### PR TITLE
Guarantee remote test buckets are cleaned up in CI

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -109,6 +109,15 @@ jobs:
           distribution: 'liberica'
           cache: 'gradle'
 
+      # Deterministic per-commit, per-environment bucket token (lowercase — S3 names must be)
+      # shared by the test run and the cleanup step below, so cleanup can target the exact
+      # bucket even if the test JVM died before its own @AfterSuite teardown ran. The
+      # environment suffix keeps matrix jobs that share a BASE_URL from colliding on one bucket.
+      - name: Compute bucket token
+        env:
+          ENVIRONMENT: ${{ matrix.environment }}
+        run: echo "BUCKET_TOKEN=${GITHUB_SHA::12}-${ENVIRONMENT,,}" >> "$GITHUB_ENV"
+
       - name: Run EnvironmentBasedSuite against ${{ matrix.environment }}
         run: ./gradlew :modules:commons-vfs:integrationTest --tests "com.github.vfss3.commonsvfs.remote.EnvironmentBasedSuite"
 
@@ -119,3 +128,9 @@ jobs:
           report_paths: '**/build/test-results/integrationTest/*.xml'
           annotate_only: true
           job_summary: true
+
+      # Runs regardless of test outcome — deletes the per-commit bucket (BASE_URL +
+      # BUCKET_TOKEN) so failed/killed runs don't leak buckets on the remote backend.
+      - name: Drop remote test bucket
+        if: always()
+        run: ./gradlew :modules:commons-vfs:dropRemoteBucket

--- a/modules/commons-vfs/build.gradle
+++ b/modules/commons-vfs/build.gradle
@@ -53,3 +53,17 @@ tasks.named('integrationTest', Test) {
         exclude '**/remote/EnvironmentBasedSuite.class'
     }
 }
+
+// Standalone cleanup for the remote integration bucket. Reuses the suite's VFS deleteAll()
+// path but runs as a separate process so CI can invoke it in an `if: always()` step —
+// guaranteeing the per-commit bucket (BASE_URL + BUCKET_TOKEN) is removed even when the
+// test JVM failed or was killed before EnvironmentBasedSuite's @AfterSuite ran.
+//
+//   BASE_URL=… BUCKET_TOKEN=… AWS_ACCESS_KEY_ID=… AWS_SECRET_KEY=… \
+//     ./gradlew :modules:commons-vfs:dropRemoteBucket
+tasks.register('dropRemoteBucket', JavaExec) {
+    group = 'verification'
+    description = 'Delete the remote S3 test bucket named by BASE_URL + BUCKET_TOKEN.'
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    mainClass = 'com.github.vfss3.commonsvfs.remote.RemoteBucketCleaner'
+}

--- a/modules/commons-vfs/src/integrationTest/java/com/github/vfss3/commonsvfs/remote/EnvironmentBasedSuite.java
+++ b/modules/commons-vfs/src/integrationTest/java/com/github/vfss3/commonsvfs/remote/EnvironmentBasedSuite.java
@@ -31,12 +31,18 @@ import software.amazon.awssdk.services.s3.model.ObjectOwnership;
  * <table>
  *   <tr><th>Variable</th><th>Required by</th><th>Notes</th></tr>
  *   <tr><td>{@code BASE_URL}</td><td>this suite</td>
- *       <td>{@code printf}-style URL template — the literal {@code %s} is replaced with a
- *           random hex token at suite start so every run targets a fresh, uniquely-named
- *           bucket. Examples:<br>
+ *       <td>{@code printf}-style URL template — the literal {@code %s} is replaced with the
+ *           bucket-name token at suite start so every run targets a uniquely-named bucket.
+ *           Examples:<br>
  *           {@code s3://s3-tests-%s.ams3.digitaloceanspaces.com/}<br>
  *           {@code s3://s3-tests-%s.s3.eu-west-1.amazonaws.com/}<br>
  *           {@code s3://s3-tests-%s.storage.yandexcloud.net/}</td></tr>
+ *   <tr><td>{@code BUCKET_TOKEN}</td><td>optional</td>
+ *       <td>Token substituted for the {@code %s} placeholder. When set (CI passes the commit
+ *           SHA), the bucket name is deterministic, so a separate {@code if: always()} CI
+ *           step can delete the same bucket via {@link RemoteBucketCleaner} even if the test
+ *           JVM died before {@code @AfterSuite} ran. When blank, a random hex token is used —
+ *           handy for ad-hoc local runs.</td></tr>
  *   <tr><td>{@code AWS_ACCESS_KEY_ID}</td><td>AWS SDK</td>
  *       <td>Picked up automatically by {@code DefaultCredentialsProvider}.</td></tr>
  *   <tr><td>{@code AWS_SECRET_KEY} / {@code AWS_SECRET_ACCESS_KEY}</td><td>AWS SDK</td>
@@ -52,6 +58,7 @@ import software.amazon.awssdk.services.s3.model.ObjectOwnership;
 @SelectPackages("com.github.vfss3.commonsvfs.tests")
 public class EnvironmentBasedSuite {
     static final String ENV_BASE_URL = "BASE_URL";
+    static final String ENV_BUCKET_TOKEN = "BUCKET_TOKEN";
 
     private static final Logger log = LoggerFactory.getLogger(EnvironmentBasedSuite.class);
 
@@ -78,7 +85,14 @@ public class EnvironmentBasedSuite {
                     + " configure ~/.aws/credentials / instance profile. " + e.getMessage());
         }
 
-        String bucketUrl = String.format(urlTemplate, S3IntegrationContext.randomBucketToken());
+        // CI passes a deterministic token (the commit SHA) so the standalone
+        // RemoteBucketCleaner can target the same bucket; locally we fall back to a random one.
+        String token = System.getenv(ENV_BUCKET_TOKEN);
+        if (isBlank(token)) {
+            token = S3IntegrationContext.randomBucketToken();
+        }
+
+        String bucketUrl = String.format(urlTemplate, token);
 
         log.info("EnvironmentBasedSuite — provisioning fresh bucket at {}", bucketUrl);
 

--- a/modules/commons-vfs/src/integrationTest/java/com/github/vfss3/commonsvfs/remote/RemoteBucketCleaner.java
+++ b/modules/commons-vfs/src/integrationTest/java/com/github/vfss3/commonsvfs/remote/RemoteBucketCleaner.java
@@ -1,0 +1,87 @@
+package com.github.vfss3.commonsvfs.remote;
+
+import com.github.vfss3.commonsvfs.S3FileSystemOptions;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.VFS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+
+/**
+ * Standalone cleanup entry point for the per-commit remote integration bucket.
+ *
+ * <p>Reads the same {@code BASE_URL} template and {@code BUCKET_TOKEN} that
+ * {@link EnvironmentBasedSuite} uses, resolves the bucket root through VFS and runs
+ * {@code deleteAll()} — which removes every object and the bucket itself. It reuses the
+ * driver's own deletion path, so it works uniformly across every S3-compatible backend
+ * (AWS, Yandex, …) without any provider-specific endpoint/region parsing.
+ *
+ * <p>It is meant to be invoked from CI as a separate {@code if: always()} step, so the
+ * bucket is removed even when the test JVM failed or was killed before the suite's
+ * {@code @AfterSuite} teardown could run:
+ *
+ * <pre>{@code ./gradlew :modules:commons-vfs:dropRemoteBucket}</pre>
+ *
+ * <p>A bucket that is already gone (the happy path — the suite deleted it) is treated as
+ * success; any other failure is propagated so CI surfaces it as a red step.
+ */
+public final class RemoteBucketCleaner {
+
+    private static final Logger log = LoggerFactory.getLogger(RemoteBucketCleaner.class);
+
+    private RemoteBucketCleaner() {}
+
+    public static void main(String[] args) throws Exception {
+        String urlTemplate = System.getenv(EnvironmentBasedSuite.ENV_BASE_URL);
+        String token = System.getenv(EnvironmentBasedSuite.ENV_BUCKET_TOKEN);
+
+        if (isBlank(urlTemplate) || isBlank(token)) {
+            log.info(
+                    "RemoteBucketCleaner — {} / {} not set, nothing to clean up",
+                    EnvironmentBasedSuite.ENV_BASE_URL,
+                    EnvironmentBasedSuite.ENV_BUCKET_TOKEN);
+            return;
+        }
+
+        String bucketUrl = String.format(urlTemplate, token);
+
+        S3FileSystemOptions options = new S3FileSystemOptions();
+        options.setCredentialsProvider(DefaultCredentialsProvider.create());
+
+        try {
+            FileObject root = VFS.getManager().resolveFile(bucketUrl, options.toFileSystemOptions());
+            root.refresh();
+
+            int deleted = root.deleteAll();
+
+            log.info("RemoteBucketCleaner — deleted bucket {} ({} object(s) removed)", bucketUrl, deleted);
+        } catch (FileSystemException e) {
+            if (isMissingBucket(e)) {
+                log.info("RemoteBucketCleaner — bucket {} already gone, nothing to delete", bucketUrl);
+            } else {
+                log.warn("RemoteBucketCleaner — failed to delete bucket {}", bucketUrl, e);
+                throw e;
+            }
+        }
+    }
+
+    /** Walk the cause chain looking for the SDK's "no such bucket" / HTTP 404 signal. */
+    private static boolean isMissingBucket(Throwable t) {
+        for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+            if (cause instanceof NoSuchBucketException) {
+                return true;
+            }
+            if (cause instanceof AwsServiceException && ((AwsServiceException) cause).statusCode() == 404) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}


### PR DESCRIPTION
## Problem

Remote integration runs (`EnvironmentBasedSuite` against AWS / Yandex) generated a random bucket name **inside the test JVM** and only deleted it in `@AfterSuite`. When a test failed, the JVM was killed on timeout, or `deleteAll()` threw (it was merely logged as a warning), the bucket leaked — and nothing outside the JVM knew its name. As a result, undeleted test buckets piled up on the external S3 backends.

## Solution

Make the bucket name deterministic, set it in CI, and move teardown into a dedicated step that runs regardless of the test outcome.

- **CI computes `BUCKET_TOKEN = <short commit SHA>-<environment>`** (lowercase, as S3 requires) and shares it with both the test run and the new cleanup step. The per-environment suffix keeps matrix jobs that share a `BASE_URL` (e.g. two YANDEX environments in the same account) from colliding on a single bucket.
- **`EnvironmentBasedSuite`** uses `BUCKET_TOKEN` when present, otherwise falls back to a random token for ad-hoc local runs.
- **`RemoteBucketCleaner`** (new standalone `main`) reuses the driver's own VFS `deleteAll()` path, so it works uniformly across every S3-compatible backend with no endpoint/region parsing. A bucket that is already gone (`NoSuchBucket` / 404) is treated as success.
- **A separate `if: always()` step** runs `:modules:commons-vfs:dropRemoteBucket`, so the bucket is removed even when the test JVM died before `@AfterSuite` ran.

## Why the driver, not the `aws` / `s3cmd` CLI

`s3cmd` is not present in the `ubuntu-latest` image; the `aws` CLI is, but `BASE_URL` is a virtual-hosted template, so the CLI would require parsing the bucket name and endpoint out of the URL by hand plus per-provider handling (region for AWS, addressing style for others). The driver-based cleaner reuses the very same S3 client that just created the bucket and ran the tests against it — the most reliable way to guarantee the delete actually succeeds.

## Verification

- `./gradlew :modules:commons-vfs:compileIntegrationTestJava` — BUILD SUCCESSFUL
- `./gradlew :modules:commons-vfs:spotlessJavaCheck` — passes
- `./gradlew :modules:commons-vfs:dropRemoteBucket` with no env — clean no-op, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)