### PR TITLE
Fix remote bucket cleanup to ignore only a missing bucket

### DIFF
--- a/modules/commons-vfs/src/integrationTest/java/com/github/vfss3/commonsvfs/remote/RemoteBucketCleaner.java
+++ b/modules/commons-vfs/src/integrationTest/java/com/github/vfss3/commonsvfs/remote/RemoteBucketCleaner.java
@@ -2,7 +2,6 @@ package com.github.vfss3.commonsvfs.remote;
 
 import com.github.vfss3.commonsvfs.S3FileSystemOptions;
 import org.apache.commons.vfs2.FileObject;
-import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.VFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +57,11 @@ public final class RemoteBucketCleaner {
             int deleted = root.deleteAll();
 
             log.info("RemoteBucketCleaner — deleted bucket {} ({} object(s) removed)", bucketUrl, deleted);
-        } catch (FileSystemException e) {
+        } catch (Exception e) {
+            // VFS rethrows the SDK's NoSuchBucketException (a RuntimeException) as-is rather than
+            // wrapping it in FileSystemException, so we have to catch the broader type and let
+            // isMissingBucket() decide. Only a missing bucket is the happy path; anything else
+            // is a real failure and must bubble up so CI surfaces it as a red step.
             if (isMissingBucket(e)) {
                 log.info("RemoteBucketCleaner — bucket {} already gone, nothing to delete", bucketUrl);
             } else {


### PR DESCRIPTION
## Problem

The `dropRemoteBucket` CI step fails on the happy path. When the test suite already deleted the per-commit bucket in its `@AfterSuite` teardown, the standalone `RemoteBucketCleaner` is supposed to treat the missing bucket as success — but instead the build goes red:

```
Exception in thread "main" software.amazon.awssdk.services.s3.model.NoSuchBucketException: The specified bucket does not exist.
	...
	at com.github.vfss3.commonsvfs.S3FileObject.doDelete(S3FileObject.java:229)
	at com.github.vfss3.commonsvfs.AbstractFileObject.deleteSelf(AbstractFileObject.java:455)
	...
	at com.github.vfss3.commonsvfs.remote.RemoteBucketCleaner.main(RemoteBucketCleaner.java:58)
```

## Root cause

`AbstractFileObject.deleteSelf` rethrows `RuntimeException`s as-is rather than wrapping them in `FileSystemException`:

```java
} catch (final RuntimeException re) {
    throw re;
} catch (final Exception exc) {
    throw new FileSystemException("vfs.provider/delete.error", exc, fileName);
}
```

The AWS SDK's `NoSuchBucketException` is a `RuntimeException`, so it propagates uncaught — but `RemoteBucketCleaner.main` only caught `FileSystemException`, so its `isMissingBucket()` branch was never reached and the exception escaped to `main`, failing the step.

## Fix

Catch the broader `Exception` in `RemoteBucketCleaner` and let `isMissingBucket()` decide:

- **missing bucket** → logged and treated as success (the happy path)
- **any other error** → still propagated, so CI surfaces a real failure as a red step

`isMissingBucket()` already walks the cause chain and matches both `NoSuchBucketException` and any `AwsServiceException` with HTTP 404, so it correctly handles the directly-thrown exception. The now-unused `FileSystemException` import is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)