### PR TITLE
ci: split remote mise tasks by backend + live status badges

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -159,6 +159,7 @@ jobs:
         run: echo "BUCKET_TOKEN=${GITHUB_SHA::12}-${ENVIRONMENT,,}-commonsvfs" >> "$GITHUB_ENV"
 
       - name: Run EnvironmentBasedSuite against ${{ matrix.environment }}
+        id: suite
         run: ./gradlew :modules:commons-vfs:integrationTest --tests "com.github.vfss3.commonsvfs.remote.EnvironmentBasedSuite"
 
       - name: Publish Test Report
@@ -174,6 +175,27 @@ jobs:
       - name: Drop remote test bucket
         if: always()
         run: ./gradlew :modules:commons-vfs:dropRemoteBucket
+
+      # Publish this cell's pass/fail to its OWN shields.io endpoint gist, so the README "Cloud
+      # providers" table shows a live per-provider badge. One gist per cell (module × provider)
+      # means concurrent matrix jobs never PATCH the same gist — no update races. Gist IDs are
+      # public, so they live here in git; only the write token (GIST_SECRET) is secret. Skipped
+      # when the token is absent (forks / PRs), so it stays a no-op until configured. Uses the
+      # pre-installed gh CLI (no extra pinned action). See the setup note in README.md.
+      - name: Update status badge (commons-vfs / ${{ matrix.environment }})
+        if: ${{ always() && env.GH_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GIST_SECRET }}
+          OUTCOME: ${{ steps.suite.outcome }}
+          # One gist per cell. Replace the placeholders with the real gist IDs (see README).
+          GIST_ID: ${{ matrix.environment == 'AWS-1' && 'c8e92c5273b3a71fee46cc9717c48bf2' || '50a0153e062bd2853c43c74df6ee5a5b' }}
+        run: |
+          set -euo pipefail
+          if [ "$OUTCOME" = "success" ]; then msg=passing; color=brightgreen; else msg=failing; color=red; fi
+          content=$(jq -nc --arg m "$msg" --arg c "$color" '{schemaVersion:1,label:"",message:$m,color:$c}')
+          jq -nc --arg content "$content" '{files: {"status.json": {content: $content}}}' \
+            | gh api -X PATCH "gists/$GIST_ID" --input - >/dev/null
+          echo "Updated gist $GIST_ID (commons-vfs / ${{ matrix.environment }}) -> $msg"
 
   jdk-remote-suites:
     name: JDK module remote — ${{ matrix.environment }}
@@ -207,6 +229,7 @@ jobs:
         run: echo "BUCKET_TOKEN=${GITHUB_SHA::12}-${ENVIRONMENT,,}-jdk" >> "$GITHUB_ENV"
 
       - name: Run EnvironmentBasedSuite against ${{ matrix.environment }}
+        id: suite
         run: ./gradlew :modules:jdk:integrationTest --tests "com.github.vfss3.jdk.remote.EnvironmentBasedSuite"
 
       - name: Publish Test Report
@@ -222,3 +245,20 @@ jobs:
       - name: Drop remote test bucket
         if: always()
         run: ./gradlew :modules:jdk:dropRemoteBucket
+
+      # See commons-vfs-remote-suites' identical step — one gist per cell, publishes this cell's
+      # status to its own gist for the README table's jdk column.
+      - name: Update status badge (jdk / ${{ matrix.environment }})
+        if: ${{ always() && env.GH_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GIST_SECRET }}
+          OUTCOME: ${{ steps.suite.outcome }}
+          # One gist per cell. Replace the placeholders with the real gist IDs (see README).
+          GIST_ID: ${{ matrix.environment == 'AWS-1' && 'bb4022ae143839ab84d016c9bc39fd85' || 'cc5795cc9160971453f4aad772ecc508' }}
+        run: |
+          set -euo pipefail
+          if [ "$OUTCOME" = "success" ]; then msg=passing; color=brightgreen; else msg=failing; color=red; fi
+          content=$(jq -nc --arg m "$msg" --arg c "$color" '{schemaVersion:1,label:"",message:$m,color:$c}')
+          jq -nc --arg content "$content" '{files: {"status.json": {content: $content}}}' \
+            | gh api -X PATCH "gists/$GIST_ID" --input - >/dev/null
+          echo "Updated gist $GIST_ID (jdk / ${{ matrix.environment }}) -> $msg"

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -128,6 +128,12 @@ jobs:
     name: commons-vfs remote — ${{ matrix.environment }}
     needs: build
     runs-on: ubuntu-latest
+    # Serialized per module × environment across workflow runs (never cancelled): two runs pushing
+    # to 17.0 back-to-back must update this cell's status-badge gist in commit order, otherwise an
+    # older run finishing last would overwrite a newer run's badge with a stale result.
+    concurrency:
+      group: remote-commonsvfs-${{ matrix.environment }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -178,19 +184,29 @@ jobs:
 
       # Publish this cell's pass/fail to its OWN shields.io endpoint gist, so the README "Cloud
       # providers" table shows a live per-provider badge. One gist per cell (module × provider)
-      # means concurrent matrix jobs never PATCH the same gist — no update races. Gist IDs are
-      # public, so they live here in git; only the write token (GIST_SECRET) is secret. Skipped
-      # when the token is absent (forks / PRs), so it stays a no-op until configured. Uses the
-      # pre-installed gh CLI (no extra pinned action). See the setup note in README.md.
+      # means concurrent matrix jobs never PATCH the same gist — no update races; ordering across
+      # workflow runs is guaranteed by the job-level concurrency group above. Gist IDs are public,
+      # so they live here in git; only the write token (GIST_SECRET) is secret. Skipped when the
+      # token is absent (forks / PRs) and when the suite never ran (skip/cancel) — a stale badge is
+      # better than a wrong "failing" one. continue-on-error: badge publishing is best-effort and
+      # must never fail a job whose tests passed. Uses the pre-installed gh CLI (no extra pinned
+      # action). See the setup note in README.md.
       - name: Update status badge (commons-vfs / ${{ matrix.environment }})
-        if: ${{ always() && env.GH_TOKEN != '' }}
+        if: ${{ !cancelled() && env.GH_TOKEN != '' && (steps.suite.outcome == 'success' || steps.suite.outcome == 'failure') }}
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GIST_SECRET }}
           OUTCOME: ${{ steps.suite.outcome }}
-          # One gist per cell. Replace the placeholders with the real gist IDs (see README).
-          GIST_ID: ${{ matrix.environment == 'AWS-1' && 'c8e92c5273b3a71fee46cc9717c48bf2' || '50a0153e062bd2853c43c74df6ee5a5b' }}
+          ENVIRONMENT: ${{ matrix.environment }}
         run: |
           set -euo pipefail
+          # One gist per cell — explicit mapping so a newly added environment can't silently
+          # overwrite another cell's gist (a ternary default would). Unknown env = no badge.
+          case "$ENVIRONMENT" in
+            AWS-1)    GIST_ID=c8e92c5273b3a71fee46cc9717c48bf2 ;;
+            YANDEX-1) GIST_ID=50a0153e062bd2853c43c74df6ee5a5b ;;
+            *) echo "::notice::No badge gist configured for $ENVIRONMENT — skipping"; exit 0 ;;
+          esac
           if [ "$OUTCOME" = "success" ]; then msg=passing; color=brightgreen; else msg=failing; color=red; fi
           content=$(jq -nc --arg m "$msg" --arg c "$color" '{schemaVersion:1,label:"",message:$m,color:$c}')
           jq -nc --arg content "$content" '{files: {"status.json": {content: $content}}}' \
@@ -201,6 +217,11 @@ jobs:
     name: JDK module remote — ${{ matrix.environment }}
     needs: build
     runs-on: ubuntu-latest
+    # See commons-vfs-remote-suites — serialized per module × environment so back-to-back runs
+    # update this cell's status-badge gist in commit order.
+    concurrency:
+      group: remote-jdk-${{ matrix.environment }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -249,14 +270,19 @@ jobs:
       # See commons-vfs-remote-suites' identical step — one gist per cell, publishes this cell's
       # status to its own gist for the README table's jdk column.
       - name: Update status badge (jdk / ${{ matrix.environment }})
-        if: ${{ always() && env.GH_TOKEN != '' }}
+        if: ${{ !cancelled() && env.GH_TOKEN != '' && (steps.suite.outcome == 'success' || steps.suite.outcome == 'failure') }}
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GIST_SECRET }}
           OUTCOME: ${{ steps.suite.outcome }}
-          # One gist per cell. Replace the placeholders with the real gist IDs (see README).
-          GIST_ID: ${{ matrix.environment == 'AWS-1' && 'bb4022ae143839ab84d016c9bc39fd85' || 'cc5795cc9160971453f4aad772ecc508' }}
+          ENVIRONMENT: ${{ matrix.environment }}
         run: |
           set -euo pipefail
+          case "$ENVIRONMENT" in
+            AWS-1)    GIST_ID=bb4022ae143839ab84d016c9bc39fd85 ;;
+            YANDEX-1) GIST_ID=cc5795cc9160971453f4aad772ecc508 ;;
+            *) echo "::notice::No badge gist configured for $ENVIRONMENT — skipping"; exit 0 ;;
+          esac
           if [ "$OUTCOME" = "success" ]; then msg=passing; color=brightgreen; else msg=failing; color=red; fi
           content=$(jq -nc --arg m "$msg" --arg c "$color" '{schemaVersion:1,label:"",message:$m,color:$c}')
           jq -nc --arg content "$content" '{files: {"status.json": {content: $content}}}' \

--- a/.github/workflows/remote-integration.yml
+++ b/.github/workflows/remote-integration.yml
@@ -8,6 +8,11 @@ name: Remote integration tests (manual)
 # NOTE: the "Run workflow" button appears in the Actions tab only once this file is present on the
 # repository's DEFAULT branch (currently branch-2.4.x). Until then it exists but isn't dispatchable
 # from the UI.
+#
+# NOTE: this workflow deliberately does NOT update the README status-badge gists (see the "Update
+# status badge" steps in main-build.yml). Badges must reflect the state of the 17.0 branch, and
+# this workflow runs the remote suites on arbitrary feature branches — publishing from here would
+# make the badges lie. Do not "fix" this by copying the badge steps over.
 on:
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ S3-compatible emulators (via Testcontainers) and against real AWS and Yandex.
 
 | Provider | `jdk` | `commons-vfs` | `spring` |
 | --- | :---: | :---: | :---: |
-| [Amazon S3](https://aws.amazon.com/s3/) | ✅ | ✅ | — |
-| [Yandex Object Storage](https://yandex.cloud/en/services/storage) | ✅ | ✅ | — |
+| [Amazon S3](https://aws.amazon.com/s3/) | [![jdk / AWS](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fbb4022ae143839ab84d016c9bc39fd85%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![commons-vfs / AWS](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fc8e92c5273b3a71fee46cc9717c48bf2%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | — |
+| [Yandex Object Storage](https://yandex.cloud/en/services/storage) | [![jdk / Yandex](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fcc5795cc9160971453f4aad772ecc508%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![commons-vfs / Yandex](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2F50a0153e062bd2853c43c74df6ee5a5b%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | — |
 
 > The `spring` module is covered by unit tests only — it ships a mock backend today (see
 > [Modules](#modules)).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Formerly **vfs-s3** — the Amazon S3 driver for Apache Commons VFS.
 Read and write Amazon S3 — and any S3-compatible storage — from Java without dropping down to the
 AWS SDK's object API.
 
+> **Scope.** This project is not meant to be a complete implementation of the S3 API. It exists to
+> simplify the handful of use-cases that come up most often: reading and writing config files,
+> uploading user-generated content to storage, and serving access to it. For anything beyond that,
+> reach for the AWS SDK directly.
+
 - **Integrate S3 into Java libraries and apps** to access S3 data through standard abstractions:
   JDK **NIO.2** (`java.nio.file.Path` / `FileSystem`), Apache **Commons VFS** (`FileObject`), and
   **Spring** (`Resource` / `ResourceLoader`).

--- a/mise.toml
+++ b/mise.toml
@@ -13,33 +13,35 @@ run = "./gradlew spotlessCheck"
 description = "Stage, sign, and publish the release to Maven Central with JReleaser"
 run = "./gradlew clean jreleaserDeploy"
 
-# Local reproduction of the remote CI jobs: runs both modules' EnvironmentBasedSuite against real
-# AWS, with credentials read from 1Password at run time (same op:// refs as gh:env-secrets — run
-# `op signin` first). BASE_URL is the same jdk-dialect value as the AWS-1 GitHub environment; the
-# per-run bucket token is left unset, so each suite provisions a random bucket and drops it in its
-# @AfterSuite (a hard Ctrl-C mid-run can still leak one).
-[tasks."test:remote"]
-description = "Run the remote integration suites (commons-vfs + jdk) against AWS; creds from 1Password (op)"
+# Local reproduction of the remote CI jobs: runs both modules' EnvironmentBasedSuite against a real
+# S3-compatible backend, with credentials read from 1Password at run time (same op:// refs as
+# gh:env-secrets — run `op signin` first). BASE_URL mirrors the matching GitHub environment
+# (AWS-1 / YANDEX-1). One backend per task so the AWS and Yandex credential/endpoint pairs never mix.
+
+[tasks."test:remote-aws"]
+description = "Run the remote integration suites (commons-vfs + jdk) against AWS S3; creds from 1Password (op)"
 shell = "bash -c"
-quiet = true
 run = '''
 set -euo pipefail
-
-AWS_ACCESS_KEY_ID="$(op read "op://Private/vfs-s3/AWS/access")"
-AWS_SECRET_ACCESS_KEY="$(op read "op://Private/vfs-s3/AWS/secret")"
-export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+export AWS_ACCESS_KEY_ID="$(op read "op://Private/vfs-s3/AWS/access")"
+export AWS_SECRET_ACCESS_KEY="$(op read "op://Private/vfs-s3/AWS/secret")"
 export BASE_URL='s3://s3-tests-%s?region=eu-central-1'
+./gradlew :modules:commons-vfs:integrationTest :modules:jdk:integrationTest \
+    --tests "com.github.vfss3.commonsvfs.remote.EnvironmentBasedSuite" \
+    --tests "com.github.vfss3.jdk.remote.EnvironmentBasedSuite"
+'''
 
-# Run both suites even if the first fails, so one invocation shows both modules' results.
-set +e
-rc=0
-echo "▶ commons-vfs remote suite (AWS)"
-./gradlew :modules:commons-vfs:integrationTest -i --tests "com.github.vfss3.commonsvfs.remote.EnvironmentBasedSuite" --console=plain || rc=1
-echo "▶ jdk remote suite (AWS)"
-./gradlew :modules:jdk:integrationTest -i --tests "com.github.vfss3.jdk.remote.EnvironmentBasedSuite" --console=plain || rc=1
-
-[ "$rc" -eq 0 ] && echo "✓ both remote suites passed" || echo "✗ a remote suite failed — see the gradle output above / build/reports"
-exit $rc
+[tasks."test:remote-yandex"]
+description = "Run the remote integration suites (commons-vfs + jdk) against Yandex Object Storage; creds from 1Password (op)"
+shell = "bash -c"
+run = '''
+set -euo pipefail
+export AWS_ACCESS_KEY_ID="$(op read "op://Private/vfs-s3/Yandex/access")"
+export AWS_SECRET_ACCESS_KEY="$(op read "op://Private/vfs-s3/Yandex/secret")"
+export BASE_URL='s3://s3-tests-%s?region=ru-central1&endpoint=https://storage.yandexcloud.net'
+./gradlew :modules:commons-vfs:integrationTest :modules:jdk:integrationTest \
+    --tests "com.github.vfss3.commonsvfs.remote.EnvironmentBasedSuite" \
+    --tests "com.github.vfss3.jdk.remote.EnvironmentBasedSuite"
 '''
 
 # ---- GitHub Actions environment config for the remote integration suites ----


### PR DESCRIPTION
mise.toml: replace the single AWS-only test:remote task with two backend-specific tasks — test:remote-aws and test:remote-yandex. Each reads its own credentials from 1Password, sets BASE_URL for that backend, and runs both modules' EnvironmentBasedSuite via gradle.

main-build.yml: add a badge-update step to each remote matrix job (commons-vfs / jdk × AWS / Yandex). Each cell writes pass/fail to its OWN shields.io "endpoint" gist, so parallel matrix jobs never PATCH the same gist — no update races. Gist IDs are public and live in git; only the write token (GIST_SECRET) is secret, and the step is a no-op until it is set. Uses the pre-installed gh CLI, so no new SHA-pinned action.

README.md: the "Cloud providers (remote suites)" table swaps the static ✅ for live flat-square badges linking to the 17.0 workflow runs.