### PR TITLE
ci: report build-only dependencies with development scope

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -21,3 +21,9 @@ jobs:
 
       - name: Submit Dependency Snapshot
         uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        env:
+          # Only runtime-classpath dependencies of the published modules count as 'runtime';
+          # buildSrc plugins, errorprone processors and test-only dependencies are reported
+          # as 'development' so Dependabot auto-triage rules can dismiss their alerts.
+          DEPENDENCY_GRAPH_RUNTIME_INCLUDE_CONFIGURATIONS: 'runtimeClasspath'
+          DEPENDENCY_GRAPH_RUNTIME_EXCLUDE_PROJECTS: ':buildSrc'


### PR DESCRIPTION
## What

Configure the dependency-submission workflow to limit the `runtime` scope to the `runtimeClasspath` configurations of the published modules, and exclude `buildSrc` from the runtime scope entirely.

## Why

By default the `gradle/actions/dependency-submission` action reports **every** resolved dependency with `runtime` scope — including buildSrc plugins (spotless, jreleaser, jgit), errorprone/nullaway processors and test-only dependencies (junit, testcontainers, ...). As a result, Dependabot alerts for build-time tooling are indistinguishable from alerts for dependencies that actually ship with the published artifacts, and scope-based auto-triage rules never match.

With the `DEPENDENCY_GRAPH_RUNTIME_*` filters set, everything outside the published modules' runtime classpath is submitted as `development` scope.

## Follow-up (repository settings, not in this PR)

Add a custom Dependabot auto-triage rule: `scope: development` → auto-dismiss. The built-in "Dismiss low impact issues for development-scoped dependencies" preset only covers the npm ecosystem, so it does not apply to Maven-ecosystem alerts.

## Verification

After merging, the workflow runs on push to `17.0`; alerts for errorprone/jgit/test dependencies should then show `Development` scope (filter the alert list with `scope:development`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)