### PR TITLE
Add DigitalOcean Spaces to the remote integration test matrix

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -280,7 +280,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [ AWS-1, YANDEX-1 ]
+        environment: [ AWS-1, YANDEX-1, DIGITALOCEAN-1 ]
     environment: ${{ matrix.environment }}
     env:
       BASE_URL: ${{ vars.BASE_URL }}
@@ -346,8 +346,9 @@ jobs:
           # One gist per cell — explicit mapping so a newly added environment can't silently
           # overwrite another cell's gist (a ternary default would). Unknown env = no badge.
           case "$ENVIRONMENT" in
-            AWS-1)    GIST_ID=c8e92c5273b3a71fee46cc9717c48bf2 ;;
-            YANDEX-1) GIST_ID=50a0153e062bd2853c43c74df6ee5a5b ;;
+            AWS-1)          GIST_ID=c8e92c5273b3a71fee46cc9717c48bf2 ;;
+            YANDEX-1)       GIST_ID=50a0153e062bd2853c43c74df6ee5a5b ;;
+            DIGITALOCEAN-1) GIST_ID=81d4560d27b100dc0b3f310d417048cd ;;
             *) echo "::notice::No badge gist configured for $ENVIRONMENT — skipping"; exit 0 ;;
           esac
           if [ "$OUTCOME" = "success" ]; then msg=passing; color=brightgreen; else msg=failing; color=red; fi
@@ -368,7 +369,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [ AWS-1, YANDEX-1 ]
+        environment: [ AWS-1, YANDEX-1, DIGITALOCEAN-1 ]
     environment: ${{ matrix.environment }}
     env:
       BASE_URL: ${{ vars.BASE_URL }}
@@ -422,8 +423,9 @@ jobs:
         run: |
           set -euo pipefail
           case "$ENVIRONMENT" in
-            AWS-1)    GIST_ID=bb4022ae143839ab84d016c9bc39fd85 ;;
-            YANDEX-1) GIST_ID=cc5795cc9160971453f4aad772ecc508 ;;
+            AWS-1)          GIST_ID=bb4022ae143839ab84d016c9bc39fd85 ;;
+            YANDEX-1)       GIST_ID=cc5795cc9160971453f4aad772ecc508 ;;
+            DIGITALOCEAN-1) GIST_ID=c9a5a9d7f46130f1a547cb6bc00ca372 ;;
             *) echo "::notice::No badge gist configured for $ENVIRONMENT — skipping"; exit 0 ;;
           esac
           if [ "$OUTCOME" = "success" ]; then msg=passing; color=brightgreen; else msg=failing; color=red; fi
@@ -444,7 +446,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [ AWS-1, YANDEX-1 ]
+        environment: [ AWS-1, YANDEX-1, DIGITALOCEAN-1 ]
     environment: ${{ matrix.environment }}
     env:
       BASE_URL: ${{ vars.BASE_URL }}
@@ -498,8 +500,9 @@ jobs:
         run: |
           set -euo pipefail
           case "$ENVIRONMENT" in
-            AWS-1)    GIST_ID=69bd6dc6c83e0e6e4f891bf764cbdd0f ;;
-            YANDEX-1) GIST_ID=2d18a93295dc0efec97ef105d1dac03a ;;
+            AWS-1)          GIST_ID=69bd6dc6c83e0e6e4f891bf764cbdd0f ;;
+            YANDEX-1)       GIST_ID=2d18a93295dc0efec97ef105d1dac03a ;;
+            DIGITALOCEAN-1) GIST_ID=530ac1eeeae87b82c91c65ac917ad821 ;;
             *) echo "::notice::No badge gist configured for $ENVIRONMENT — skipping"; exit 0 ;;
           esac
           if [ "$OUTCOME" = "success" ]; then msg=passing; color=brightgreen; else msg=failing; color=red; fi

--- a/.github/workflows/remote-integration.yml
+++ b/.github/workflows/remote-integration.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [ AWS-1, YANDEX-1 ]
+        environment: [ AWS-1, YANDEX-1, DIGITALOCEAN-1 ]
     environment: ${{ matrix.environment }}
     env:
       BASE_URL: ${{ vars.BASE_URL }}
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [ AWS-1, YANDEX-1 ]
+        environment: [ AWS-1, YANDEX-1, DIGITALOCEAN-1 ]
     environment: ${{ matrix.environment }}
     env:
       BASE_URL: ${{ vars.BASE_URL }}
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [ AWS-1, YANDEX-1 ]
+        environment: [ AWS-1, YANDEX-1, DIGITALOCEAN-1 ]
     environment: ${{ matrix.environment }}
     env:
       BASE_URL: ${{ vars.BASE_URL }}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ S3-compatible emulators (via Testcontainers) and against real AWS and Yandex.
 | --- | :---: | :---: | :---: |
 | [Amazon S3](https://aws.amazon.com/s3/) | [![jdk / AWS](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fbb4022ae143839ab84d016c9bc39fd85%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![commons-vfs / AWS](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fc8e92c5273b3a71fee46cc9717c48bf2%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![spring / AWS](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2F69bd6dc6c83e0e6e4f891bf764cbdd0f%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) |
 | [Yandex Object Storage](https://yandex.cloud/en/services/storage) | [![jdk / Yandex](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fcc5795cc9160971453f4aad772ecc508%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![commons-vfs / Yandex](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2F50a0153e062bd2853c43c74df6ee5a5b%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![spring / Yandex](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2F2d18a93295dc0efec97ef105d1dac03a%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) |
+| [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces) | [![jdk / DigitalOcean](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fc9a5a9d7f46130f1a547cb6bc00ca372%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![commons-vfs / DigitalOcean](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2F81d4560d27b100dc0b3f310d417048cd%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![spring / DigitalOcean](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2F530ac1eeeae87b82c91c65ac917ad821%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) |
 
 ### Versioning
 
@@ -101,23 +102,19 @@ All published under the `com.github.abashev` group, at one shared version:
 Depend on the module you need (Gradle shown; Maven is analogous):
 
 ```gradle
-implementation 'com.github.abashev:vfs-jdk:17.0.0'      // JDK NIO.2 FileSystemProvider
-implementation 'com.github.abashev:vfs-commons:17.0.0'  // Apache Commons VFS provider
-implementation 'com.github.abashev:vfs-spring:17.0.0'   // Spring Resource / ResourceLoader
+implementation 'com.github.abashev:vfs-jdk:17.0.1'      // JDK NIO.2 FileSystemProvider
+implementation 'com.github.abashev:vfs-commons:17.0.1'  // Apache Commons VFS provider
+implementation 'com.github.abashev:vfs-spring:17.0.1'   // Spring Resource / ResourceLoader
 ```
 
 ```xml
 <dependency>
     <groupId>com.github.abashev</groupId>
     <artifactId>vfs-jdk</artifactId>
-    <version>17.0.0</version>
+    <version>17.0.1</version>
 </dependency>
 ```
 
-> **None of the `vfs-*` artifacts are on Maven Central yet** — they publish from the next `17.0.x`
-> release. The current `17.0.0` is available under the old coordinates (`jdk`, `commons-vfs`,
-> `spring-6`, `spring-7`), now retired.
->
 > Legacy Java 8 line: `com.github.abashev:vfs-s3:4.4.0` (or `vfs-s3-with-awssdk-v1:4.4.0` with the
 > AWS SDK v1 bundled).
 
@@ -325,8 +322,9 @@ This project uses [mise](https://mise.jdx.dev/) to manage the local Java toolcha
     mise exec -- ./gradlew :modules:jdk:test     # one module's unit tests
 
 Handy `mise` tasks (see `mise.toml`): `mise run format`, `mise run format.check`, and
-`mise run test:remote` (remote suites against AWS). Integration tests spin up S3-compatible
-containers (LocalStack, MinIO, Garage, …) via Testcontainers.
+`mise run test:remote-aws` / `test:remote-yandex` / `test:remote-digitalocean` (remote suites
+against each provider). Integration tests spin up S3-compatible containers (LocalStack, MinIO,
+Garage, …) via Testcontainers.
 
 On CI (GitHub Actions) Java is installed via `actions/setup-java`, so `./gradlew` runs directly
 without `mise`.
@@ -344,8 +342,9 @@ Provide them either way:
 
 2. Or any standard AWS SDK mechanism (IAM role, `~/.aws`, …)
 
-Locally, `mise run test:remote-aws` runs every module's remote suite against AWS with credentials
-read from 1Password — see `mise.toml`.
+Locally, `mise run test:remote-aws` / `test:remote-yandex` / `test:remote-digitalocean` run every
+module's remote suite against AWS, Yandex Object Storage, and DigitalOcean Spaces respectively,
+with credentials read from 1Password — see `mise.toml`.
 
 **Make sure that you never commit your credentials!**
 

--- a/mise.toml
+++ b/mise.toml
@@ -46,6 +46,20 @@ export BASE_URL='s3://s3-tests-%s?region=ru-central1&endpoint=https://storage.ya
     --tests "com.github.vfss3.spring.remote.EnvironmentBasedSuite"
 '''
 
+[tasks."test:remote-digitalocean"]
+description = "Run the remote integration suites (commons-vfs + jdk + spring) against DigitalOcean Spaces; creds from 1Password (op)"
+shell = "bash -c"
+run = '''
+set -euo pipefail
+export AWS_ACCESS_KEY_ID="$(op read "op://Private/vfs-s3/DigitalOcean/access")"
+export AWS_SECRET_ACCESS_KEY="$(op read "op://Private/vfs-s3/DigitalOcean/secret")"
+export BASE_URL='s3://s3-tests-%s?region=ams3&endpoint=https://ams3.digitaloceanspaces.com'
+./gradlew :modules:commons-vfs:integrationTest :modules:jdk:integrationTest :modules:spring:integrationTest \
+    --tests "com.github.vfss3.commonsvfs.remote.EnvironmentBasedSuite" \
+    --tests "com.github.vfss3.jdk.remote.EnvironmentBasedSuite" \
+    --tests "com.github.vfss3.spring.remote.EnvironmentBasedSuite"
+'''
+
 # ---- GitHub Actions environment config for the remote integration suites ----
 # Non-secret variables live here in git; secrets are read from 1Password at apply time and are
 # never stored in the repo. Both tasks are idempotent and skip any entry still set to a TODO
@@ -64,7 +78,8 @@ set -euo pipefail
 # BASE_URL per environment, in the jdk s3://<bucket>?region=…&endpoint=… dialect (ADR-006, the
 # canonical CI variable — commons-vfs translates it to its own dialect in a test-only adapter).
 # The %s in the bucket is the per-run bucket-name token, shared by both modules' remote suites.
-# Only AWS-1 and YANDEX-1 are in the remote matrix; DIGITALOCEAN-1 is set but not wired into a suite.
+# Only AWS-1 and YANDEX-1 are in the CI remote matrix; DIGITALOCEAN-1 is set here too but only
+# wired into a local task (test:remote-digitalocean), not into the CI workflow.
 apply() {
   local env="$1" base_url="$2"
   if [[ "$base_url" == TODO* ]]; then


### PR DESCRIPTION
## Summary
- `DIGITALOCEAN-1` already had its GitHub environment, `BASE_URL`, and secrets configured (from `mise run gh:env-vars` / `gh:env-secrets`) but wasn't wired into any test suite — this wires it in alongside `AWS-1`/`YANDEX-1`.
- New local task `mise run test:remote-digitalocean`; verified locally — all three module suites (commons-vfs, jdk, spring) pass against real DigitalOcean Spaces (17m28s).
- `main-build.yml`: `DIGITALOCEAN-1` added to the push-to-`17.0` remote matrix, with its own status-badge gist per module (new secret gists, same pattern as the AWS/Yandex ones).
- `remote-integration.yml`: `DIGITALOCEAN-1` added to the on-demand matrix (no badge updates there, by that workflow's existing design).
- README: new DigitalOcean Spaces row in the cloud-providers table; documents `test:remote-yandex`/`test:remote-digitalocean` where only `test:remote-aws` was mentioned before; fixes a stale `mise run test:remote` reference (task doesn't exist under that name).
- Also refreshes README for the 17.0.1 release (version bump in the install snippets, drops the now-stale "not yet on Maven Central" / `spring-6`/`spring-7` note).

## Test plan
- [x] `mise run test:remote-digitalocean` — BUILD SUCCESSFUL, all three `EnvironmentBasedSuite` runs passed against real DigitalOcean Spaces
- [x] Both workflow YAML files parse cleanly (validated with PyYAML)
- [ ] After merge: confirm the `main-build.yml` push-to-`17.0` run populates the three new gist badges correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)