### PR TITLE
Add jdk and commons-vfs samples; keep samples/ out of the format check

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,11 +6,26 @@ CACHE_DIR="${HOME}/.cache/palantir-java-format"
 BINARY="${CACHE_DIR}/palantir-java-format-${FORMATTER_VERSION}"
 BASE_URL="https://repo1.maven.org/maven2/com/palantir/javaformat/palantir-java-format-native/${FORMATTER_VERSION}"
 
-# Collect staged Java files. `samples/` is excluded: those files are standalone scripts whose
-# tool directives (jbang's `///usr/bin/env`, `//DEPS`, …) the formatter would rewrite into
-# ordinary comments and break. They are outside every Gradle source set, so spotless skips them
-# too — see the `target 'src/*/java/**/*.java'` in buildSrc's java-conventions.
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.java' ':(exclude)samples/**' || true)
+# Read exclude patterns from .palantir-java-format-exclude (repo root), if present.
+# Each non-empty, non-comment line is a git pathspec whose matches are skipped.
+# This file is the single source of exclusions, shared with the GitHub Action.
+EXCLUDES=()
+EXCLUDE_FILE=".palantir-java-format-exclude"
+if [ -f "$EXCLUDE_FILE" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        case "$line" in ''|\#*) continue ;; esac
+        EXCLUDES+=(":(exclude)$line")
+    done < "$EXCLUDE_FILE"
+fi
+
+# Collect staged Java files (respecting excludes)
+if [ ${#EXCLUDES[@]} -gt 0 ]; then
+    STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.java' "${EXCLUDES[@]}" || true)
+else
+    STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.java' || true)
+fi
 
 if [ -z "$STAGED_FILES" ]; then
     exit 0

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: abashev/palantir-java-format-action@48b49096dd157e34c0cf7df617e2a88578f2fc1c # v1
+      # Exclusions live in .palantir-java-format-exclude at the repo root — the action and
+      # .githooks/pre-commit both read that file, so there is nothing to configure here.
+      - uses: abashev/palantir-java-format-action@ed91d1afe3e00201f6ef4126b6215d697737f75b # v1
         with:
           version: '2.96.0'
           mode: 'all'

--- a/.palantir-java-format-exclude
+++ b/.palantir-java-format-exclude
@@ -1,0 +1,7 @@
+# Paths palantir-java-format must not touch. Git pathspecs, one per line; read by both the
+# format-check workflow and .githooks/pre-commit, so the two never drift apart.
+
+# Standalone jbang scripts: the formatter rewrites their `//DEPS` directives into ordinary
+# `// DEPS` comments, and jbang then stops resolving the dependencies. These files are outside
+# every Gradle source set, so spotless never covered them either.
+samples/**

--- a/README.md
+++ b/README.md
@@ -170,6 +170,24 @@ try (OutputStream out = file.getContent().getOutputStream()) {
 
 → more in [commons-vfs module usage](#commons-vfs-module).
 
+### Runnable samples
+
+Each snippet above also exists as a single-file [jbang](https://www.jbang.dev/) application in
+[`samples/`](samples) — same three lines of real work, wired to a local MinIO instead of AWS.
+Docker is the only prerequisite; `mise` installs Java and jbang itself:
+
+    cd samples
+    mise trust
+    mise run demo               # start MinIO, create the bucket, run all three samples
+    mise run demo:jdk           # … or just one of them (jdk / commons-vfs / spring)
+    mise run down               # stop and remove the container
+
+| Module | Sample | What it shows |
+| --- | --- | --- |
+| jdk | [S3JdkSample.java](samples/jdk/S3JdkSample.java) | a bucket opened as a `FileSystem`, then plain `Files.writeString` / `readString` |
+| commons-vfs | [S3CommonsVfsSample.java](samples/commons-vfs/S3CommonsVfsSample.java) | a `FileObject` resolved from a legacy-dialect URL, written and read back |
+| spring | [S3SpringSample.java](samples/spring/S3SpringSample.java) | an `s3://` object injected with `@Value`, written and read back |
+
 ### URL scheme
 
 The canonical scheme is a plain, secret-free `s3://` URI — the bucket is the host, and the only
@@ -243,6 +261,9 @@ try (FileSystem fs = FileSystems.newFileSystem(bucket, env)) {
 }
 ```
 
+Runnable version: [samples/jdk/S3JdkSample.java](samples/jdk/S3JdkSample.java) — see
+[runnable samples](#runnable-samples).
+
 #### commons-vfs module
 
 The mature Apache Commons VFS provider. It resolves `s3://` URLs in its own [legacy
@@ -262,6 +283,9 @@ FileObject b = fs.resolveFile("s3://s3.eu-central-1.amazonaws.com/my-bucket/dir/
 ```
 
 Credentials come from the AWS SDK default chain, or from `S3FileSystemOptions.setCredentialsProvider(...)`.
+
+Runnable version: [samples/commons-vfs/S3CommonsVfsSample.java](samples/commons-vfs/S3CommonsVfsSample.java) —
+see [runnable samples](#runnable-samples).
 
 #### spring module
 
@@ -311,6 +335,9 @@ try (var resolver = new S3ResourcePatternResolver()) {
     Resource[] reports = resolver.getResources("s3://my-bucket/reports/*.csv");
 }
 ```
+
+Runnable version: [samples/spring/S3SpringSample.java](samples/spring/S3SpringSample.java) — see
+[runnable samples](#runnable-samples).
 
 ### Local development
 

--- a/samples/commons-vfs/S3CommonsVfsSample.java
+++ b/samples/commons-vfs/S3CommonsVfsSample.java
@@ -1,0 +1,67 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 17
+//DEPS com.github.abashev:vfs-commons:17.0.1
+//DEPS org.apache.commons:commons-vfs2:2.10.0
+//DEPS org.slf4j:slf4j-nop:2.0.18
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.github.vfss3.commonsvfs.S3FileSystemOptions;
+import java.net.URI;
+import org.apache.commons.vfs2.VFS;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+/**
+ * The smallest useful application on top of {@code com.github.abashev:vfs-commons}: an S3 object is
+ * resolved as an Apache Commons VFS {@code FileObject}, written and read back.
+ *
+ * <p>Run it against the MinIO container from {@code ../mise.toml}:
+ *
+ * <pre>
+ * mise trust
+ * mise run demo:commons-vfs
+ * </pre>
+ */
+public class S3CommonsVfsSample {
+
+    public static void main(String[] args) throws Exception {
+        var options = new S3FileSystemOptions();
+        options.setCredentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
+                env("AWS_ACCESS_KEY_ID", "minioadmin"), env("AWS_SECRET_ACCESS_KEY", "minioadmin"))));
+        // Both settings exist for local and S3-compatible servers; against real AWS neither is
+        // needed — credentials alone (or the AWS SDK default chain) are enough.
+        options.setUseHttps(false);
+        options.setDisableChunkedEncoding(true);
+
+        // This module keeps the legacy dialect: the endpoint is the host, and the bucket is the
+        // first path segment. Against AWS the host carries the region instead, as in
+        // s3://my-bucket.s3.eu-central-1.amazonaws.com/commons-vfs/hello.txt
+        var endpoint = URI.create(env("S3_ENDPOINT", "http://localhost:9000"));
+        var url = "s3://" + endpoint.getHost() + ":" + endpoint.getPort() + "/" + env("BUCKET", "vfs-s3-sample")
+                + "/commons-vfs/hello.txt";
+
+        var manager = VFS.getManager();
+        var file = manager.resolveFile(url, options.toFileSystemOptions());
+
+        try {
+            try (var out = file.getContent().getOutputStream()) {
+                out.write("Hello from Commons VFS!\n".getBytes(UTF_8));
+            }
+            System.out.println(
+                    "wrote     " + file.getName().getURI() + " (" + file.getContent().getSize() + " bytes)");
+
+            try (var in = file.getContent().getInputStream()) {
+                System.out.println("read back " + new String(in.readAllBytes(), UTF_8).strip());
+            }
+        } finally {
+            // Closing the file system shuts down the transfer threads, so the JVM can exit.
+            manager.closeFileSystem(file.getFileSystem());
+        }
+    }
+
+    private static String env(String name, String fallback) {
+        var value = System.getenv(name);
+        return (value == null || value.isBlank()) ? fallback : value;
+    }
+}

--- a/samples/jdk/S3JdkSample.java
+++ b/samples/jdk/S3JdkSample.java
@@ -1,0 +1,55 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 17
+//DEPS com.github.abashev:vfs-jdk:17.0.1
+//DEPS org.slf4j:slf4j-nop:2.0.18
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.util.Map;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+/**
+ * The smallest useful application on top of {@code com.github.abashev:vfs-jdk}: an S3 bucket is
+ * opened as a {@link java.nio.file.FileSystem}, and the object is written and read back through
+ * plain {@link Files} calls.
+ *
+ * <p>Run it against the MinIO container from {@code ../mise.toml}:
+ *
+ * <pre>
+ * mise trust
+ * mise run demo:jdk
+ * </pre>
+ */
+public class S3JdkSample {
+
+    public static void main(String[] args) throws IOException {
+        // The canonical URL scheme: the bucket is the host and the rest of the configuration rides
+        // in the query. Against real AWS the query is usually just `?region=…`, or nothing at all.
+        // Credentials are never part of a URL — they travel in the env map below, and without one
+        // the AWS SDK default chain is used.
+        var bucket = URI.create("s3://" + env("BUCKET", "vfs-s3-sample") + "?region="
+                + env("AWS_REGION", "us-east-1") + "&endpoint=" + env("S3_ENDPOINT", "http://localhost:9000"));
+        var credentials = StaticCredentialsProvider.create(AwsBasicCredentials.create(
+                env("AWS_ACCESS_KEY_ID", "minioadmin"), env("AWS_SECRET_ACCESS_KEY", "minioadmin")));
+
+        try (var fs = FileSystems.newFileSystem(bucket, Map.of("credentialsProvider", credentials))) {
+            // From here on nothing is S3-specific — this is the java.nio.file API you already know.
+            var file = fs.getPath("/jdk/hello.txt");
+
+            Files.writeString(file, "Hello from java.nio.file!\n", UTF_8);
+            System.out.println("wrote     " + file.toUri() + " (" + Files.size(file) + " bytes)");
+
+            System.out.println("read back " + Files.readString(file, UTF_8).strip());
+        }
+    }
+
+    private static String env(String name, String fallback) {
+        var value = System.getenv(name);
+        return (value == null || value.isBlank()) ? fallback : value;
+    }
+}

--- a/samples/mise.toml
+++ b/samples/mise.toml
@@ -1,10 +1,10 @@
-# Self-contained playground for the `spring` module: a local MinIO container plus the one-file
-# jbang application in S3SpringSample.java, which writes and reads an s3:// object injected
-# with @Value.
+# Self-contained playground for the three modules: one local MinIO container plus the single-file
+# jbang applications next to this file, each writing and reading one s3:// object.
 #
-#   mise trust            # once — mise only runs configs you have trusted
-#   mise run demo         # start MinIO, create the bucket, run the application
-#   mise run down         # stop and remove the container
+#   mise trust                  # once — mise only runs configs you have trusted
+#   mise run demo               # start MinIO, create the bucket, run all three samples
+#   mise run demo:jdk           # … or just one of them (jdk / commons-vfs / spring)
+#   mise run down               # stop and remove the container
 #
 # Docker has to be running and port 9000 free; Java and jbang are installed by mise itself.
 
@@ -13,15 +13,16 @@ java = "liberica-17"
 "aqua:jbangdev/jbang" = "0.141.0"
 
 [env]
-# MinIO's root user doubles as the S3 access key/secret. The application reads all four values
-# from the environment (see env(…) in S3SpringSample.java) and falls back to the same defaults,
-# so it stays runnable on its own — `jbang S3SpringSample.java`.
+# MinIO's root user doubles as the S3 access key/secret. Every sample reads these values from the
+# environment (see env(…) in each file) and falls back to the same defaults, so each one also runs
+# on its own — `jbang jdk/S3JdkSample.java`.
 AWS_ACCESS_KEY_ID = "minioadmin"
 AWS_SECRET_ACCESS_KEY = "minioadmin"
 AWS_REGION = "us-east-1"
 S3_ENDPOINT = "http://localhost:9000"
 
-# Must match the bucket in the @Value location of S3SpringSample.java.
+# One bucket for all three samples, one key prefix each. The spring sample takes the bucket from
+# its @Value location rather than the environment, so keep the name in sync with it.
 BUCKET = "vfs-s3-sample"
 CONTAINER = "vfs-s3-sample-minio"
 IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z"
@@ -57,9 +58,28 @@ exit 1
 '''
 
 [tasks.demo]
+description = "Run all three samples against the local MinIO"
+depends = ["up"]
+run = [
+    "jbang {{config_root}}/jdk/S3JdkSample.java",
+    "jbang {{config_root}}/commons-vfs/S3CommonsVfsSample.java",
+    "jbang {{config_root}}/spring/S3SpringSample.java",
+]
+
+[tasks."demo:jdk"]
+description = "Run the JDK NIO.2 sample against the local MinIO"
+depends = ["up"]
+run = "jbang {{config_root}}/jdk/S3JdkSample.java"
+
+[tasks."demo:commons-vfs"]
+description = "Run the Apache Commons VFS sample against the local MinIO"
+depends = ["up"]
+run = "jbang {{config_root}}/commons-vfs/S3CommonsVfsSample.java"
+
+[tasks."demo:spring"]
 description = "Run the Spring sample against the local MinIO"
 depends = ["up"]
-run = "jbang {{config_root}}/S3SpringSample.java"
+run = "jbang {{config_root}}/spring/S3SpringSample.java"
 
 [tasks.down]
 description = "Stop and remove the MinIO container"

--- a/samples/spring/S3SpringSample.java
+++ b/samples/spring/S3SpringSample.java
@@ -34,7 +34,7 @@ public class S3SpringSample {
      * injected exactly like a {@code classpath:} or {@code file:} one. No AWS SDK type in sight —
      * the bucket only has to exist, the object does not.
      */
-    @Value("s3://vfs-s3-sample/reports/hello.txt")
+    @Value("s3://vfs-s3-sample/spring/hello.txt")
     private WritableResource report;
 
     private void run() throws IOException {


### PR DESCRIPTION
Follow-up to #358, which added the Spring sample: the other two modules get one as well, and the
format check stops tripping over them.

## Samples

`samples/jdk/S3JdkSample.java` and `samples/commons-vfs/S3CommonsVfsSample.java` follow the shape
of the Spring one, so the three can be read side by side — a single jbang file per module that
writes one object and reads it back, with the module-specific wiring being the only difference:

| Module | What the sample shows |
| --- | --- |
| jdk | a bucket opened as a `FileSystem`, then plain `Files.writeString` / `readString` |
| commons-vfs | a `FileObject` resolved from a legacy-dialect URL, plus `S3FileSystemOptions` |
| spring | an `s3://` object injected with `@Value` |

The MinIO container is now shared: `mise.toml` moves up to `samples/`, keeps one bucket with a key
prefix per sample, and gains `demo:<module>` tasks next to `demo`, which runs all three. mise merges
configs from parent directories, so the samples still run from their own folders. Each file also
runs standalone (`jbang jdk/S3JdkSample.java`) — the environment values it reads double as defaults.

The README gets a "Runnable samples" section after the quick start, plus a pointer at the end of
each module usage section.

## Format check

The check runs with `mode: all`, so it also picked up the jbang scripts and turned 17.0 red. Those
files cannot be "fixed": the formatter rewrites their `//DEPS` directives into ordinary `// DEPS`
comments, and jbang then stops resolving the dependencies.

The action now reads exclusions from `.palantir-java-format-exclude` in the repo root, so that file
is added here with `samples/**`, the pin moves to the release that supports it, and
`.githooks/pre-commit` is synced with the action's own hook, which reads the very same file — CI and
the local hook can no longer disagree about what is excluded. The split between them is unchanged:
the hook checks staged files, CI checks everything. Spotless was never involved; it targets
`src/*/java/**/*.java` per module.

## Verification

- All three samples run green against a fresh MinIO container (`mise run demo`), objects confirmed
  with `mc ls` in the bucket.
- The action's collection logic, run verbatim against this repository: 136 Java files → 133, the
  three samples dropped, every `modules/**` source kept.
- The hook: a deliberately unformatted sample file is skipped (exit 0), while the same breakage in
  `modules/jdk/src/test` fails the hook as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)