### PR TITLE
test: add a Ceph integration suite to all three modules

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -61,6 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         suite:
+          - CephSuite
           - LocalStackSuite
           - MinioSuite
           - CloudServerSuite
@@ -208,6 +209,7 @@ jobs:
       fail-fast: false
       matrix:
         suite:
+          - CephSuite
           - LocalStackSuite
           - MinioSuite
           - CloudServerSuite

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$SUITE" in
+            CephSuite)        GIST_ID=d250da08c07fe233e625f79513459997 ;;
             LocalStackSuite)  GIST_ID=b4b0eaf73f6efc7d4f6f00430acb113c ;;
             MinioSuite)       GIST_ID=515d7a1f7c705dcb4bdb94ed2bc3d3fb ;;
             CloudServerSuite) GIST_ID=da9fc57b268821a47cb4c47585429682 ;;
@@ -179,6 +180,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$SUITE" in
+            CephSuite)        GIST_ID=df4931187971a0c68a0461827423cd9c ;;
             LocalStackSuite)  GIST_ID=5a8157db7a423426d6e431e017eab6de ;;
             MinioSuite)       GIST_ID=f259b78ba82183bf7e0c6a452f2a2614 ;;
             CloudServerSuite) GIST_ID=f7194330b0c4fd817c44d4f7d45901e5 ;;
@@ -253,6 +255,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$SUITE" in
+            CephSuite)        GIST_ID=d5e8053ff3df3561f7c8b6691fb0099d ;;
             LocalStackSuite)  GIST_ID=c77436e3016d4d2e9721a7c44c871aca ;;
             MinioSuite)       GIST_ID=aea35bf96cf017ec2a5dabae35d95dde ;;
             CloudServerSuite) GIST_ID=d4d4ad377a4b5b2953a6c13772dcf461 ;;

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -134,6 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         suite:
+          - CephSuite
           - LocalStackSuite
           - MinioSuite
           - CloudServerSuite

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -57,6 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         suite:
+          - CephSuite
           - LocalStackSuite
           - MinioSuite
           - CloudServerSuite
@@ -134,6 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         suite:
+          - CephSuite
           - LocalStackSuite
           - MinioSuite
           - CloudServerSuite

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -95,6 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         suite:
+          - CephSuite
           - LocalStackSuite
           - MinioSuite
           - CloudServerSuite

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ AWS SDK's object API.
   URL (see [URL scheme](#url-scheme)).
 - **Built on the AWS SDK for Java v2**, Java 17.
 - **Works with real AWS and many S3-compatible backends** — Yandex Object Storage, DigitalOcean
-  Spaces, MinIO, Garage, LocalStack, and more.
+  Spaces, Ceph, MinIO, Garage, LocalStack, and more.
 
 ### History
 
@@ -36,13 +36,14 @@ Commons VFS provider for backward compatibility.
 
 ### Tested against
 
-Every push builds and runs the `jdk`, `commons-vfs` and `spring` integration suites against nine
-S3-compatible emulators (via Testcontainers) and against real AWS and Yandex.
+Every push builds and runs the `jdk`, `commons-vfs` and `spring` integration suites against ten
+S3-compatible backends (via Testcontainers) and against real AWS and Yandex.
 
-**Local emulators (Testcontainers):**
+**Local backends (Testcontainers):**
 
 | Backend | `jdk` | `commons-vfs` | `spring` |
 | --- | :---: | :---: | :---: |
+| [Ceph](https://ceph.io/) | [![jdk / Ceph](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fdf4931187971a0c68a0461827423cd9c%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![commons-vfs / Ceph](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fd250da08c07fe233e625f79513459997%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![spring / Ceph](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fd5e8053ff3df3561f7c8b6691fb0099d%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) |
 | [LocalStack](https://www.localstack.cloud/) | [![jdk / LocalStack](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2F5a8157db7a423426d6e431e017eab6de%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![commons-vfs / LocalStack](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fb4b0eaf73f6efc7d4f6f00430acb113c%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![spring / LocalStack](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Fc77436e3016d4d2e9721a7c44c871aca%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) |
 | [MinIO](https://min.io/) | [![jdk / MinIO](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Ff259b78ba82183bf7e0c6a452f2a2614%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![commons-vfs / MinIO](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2F515d7a1f7c705dcb4bdb94ed2bc3d3fb%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![spring / MinIO](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Faea35bf96cf017ec2a5dabae35d95dde%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) |
 | [Garage](https://garagehq.deuxfleurs.fr/) | [![jdk / Garage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Ff46a1f533f24872a42fa876ba39dd7f8%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![commons-vfs / Garage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2Facf0cdd3085b634070007b65ca877e62%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) | [![spring / Garage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fabashev%2F17d044c2ea78d64256f18142657b8a3c%2Fraw%2Fstatus.json&style=flat-square)](https://github.com/abashev/vfs-s3/actions/workflows/main-build.yml?query=branch%3A17.0) |

--- a/modules/commons-vfs/src/integrationTest/java/com/github/vfss3/commonsvfs/local/CephSuite.java
+++ b/modules/commons-vfs/src/integrationTest/java/com/github/vfss3/commonsvfs/local/CephSuite.java
@@ -1,0 +1,78 @@
+package com.github.vfss3.commonsvfs.local;
+
+import com.github.vfss3.commonsvfs.S3FileSystemOptions;
+import com.github.vfss3.commonsvfs.S3IntegrationContext;
+import java.net.URI;
+import java.time.Duration;
+import org.junit.platform.suite.api.*;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+/**
+ * Runs every test in {@code com.github.vfss3.commonsvfs.tests} against a freshly-started Ceph
+ * container — a single-node cluster (MON, MGR, OSD) with the RADOS Gateway, Ceph's S3 front end,
+ * on top of it. See {@code modules/jdk}'s {@code local.CephSuite} for why each environment
+ * variable below is needed, why the wait strategy keys off a log line, and why the image cannot
+ * run on an arm64 host.
+ *
+ * <p>Unlike the other local backends this one is left on the platform features the parser derives
+ * for a custom endpoint, which include ACL support: RGW implements S3 ACLs, so there is no reason
+ * to opt out of {@code AclTest} the way the emulator suites do.
+ */
+@SelectPackages("com.github.vfss3.commonsvfs.tests")
+@Suite
+@SuiteDisplayName("Ceph integration tests")
+@SuppressWarnings("NullAway")
+public class CephSuite {
+    private static final DockerImageName IMAGE = DockerImageName.parse("quay.io/ceph/demo:latest-squid");
+    private static final int RGW_PORT = 8080;
+    private static final String ACCESS_KEY = "vfs-s3-tests";
+    private static final String SECRET_KEY = "vfs-s3-tests-secret";
+
+    private static GenericContainer<?> container;
+
+    @BeforeSuite
+    static void startContainer() {
+        container = new GenericContainer<>(IMAGE)
+                // Mandatory for the demo entrypoint; everything is reached through the published
+                // RGW port, so loopback is enough.
+                .withEnv("MON_IP", "127.0.0.1")
+                .withEnv("CEPH_PUBLIC_NETWORK", "0.0.0.0/0")
+                // MON and MGR are always bootstrapped — this drops MDS, NFS, rbd-mirror and crash.
+                .withEnv("DEMO_DAEMONS", "osd rgw")
+                .withEnv("CEPH_DEMO_UID", "vfs-s3")
+                .withEnv("CEPH_DEMO_ACCESS_KEY", ACCESS_KEY)
+                .withEnv("CEPH_DEMO_SECRET_KEY", SECRET_KEY)
+                .withEnv("RGW_NAME", "localhost")
+                // Keeps the monitor from refusing to start on a nearly-full Docker VM disk.
+                .withEnv("CEPH_ARGS", "--mon-data-avail-crit=0 --mon-data-avail-warn=0")
+                .withExposedPorts(RGW_PORT)
+                // RGW listens before the demo user is created, so waiting on the port would race.
+                .waitingFor(Wait.forLogMessage(".*bin/demo: SUCCESS.*", 1).withStartupTimeout(Duration.ofMinutes(5)));
+        container.start();
+
+        S3FileSystemOptions options = new S3FileSystemOptions();
+        options.setCredentialsProvider(
+                StaticCredentialsProvider.create(AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)));
+        options.setUseHttps(false);
+        options.setDisableChunkedEncoding(true);
+
+        URI endpoint = URI.create("http://" + container.getHost() + ":" + container.getMappedPort(RGW_PORT));
+        S3IntegrationContext.initialize(endpoint, options);
+    }
+
+    @AfterSuite
+    static void stopContainer() {
+        try {
+            S3IntegrationContext.reset();
+        } finally {
+            if (container != null) {
+                container.stop();
+                container = null;
+            }
+        }
+    }
+}

--- a/modules/jdk/src/integrationTest/java/com/github/vfss3/jdk/local/CephSuite.java
+++ b/modules/jdk/src/integrationTest/java/com/github/vfss3/jdk/local/CephSuite.java
@@ -1,0 +1,90 @@
+package com.github.vfss3.jdk.local;
+
+import com.github.vfss3.jdk.JdkIntegrationContext;
+import java.net.URI;
+import java.time.Duration;
+import org.junit.platform.suite.api.*;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+/**
+ * Runs every test in {@code com.github.vfss3.jdk.tests} against a freshly-started Ceph container.
+ * Unlike the other local backends this is not an S3 emulator but the real thing — the demo image
+ * bootstraps a single-node cluster (MON, MGR, OSD) and puts the RADOS Gateway, Ceph's S3 front
+ * end, on top of it.
+ *
+ * <p><b>Image:</b> {@code quay.io/ceph/demo} is the only single-container Ceph distribution there
+ * is. Its {@code ceph/ceph-container} project was archived in December 2024, so the {@code
+ * latest-*} tags are frozen rather than rolling and there are no version-pinned tags to use
+ * instead. {@code latest-squid} is Ceph 19.2.0; the older {@code latest-reef} / {@code
+ * latest-quincy} tags predate parts of the checksum handling AWS SDK 2.30+ sends by default.
+ *
+ * <p><b>Known limitation:</b> the image is amd64-only, and unlike {@code CloudServerSuite} it does
+ * not merely run slowly under emulation on an arm64 host — it cannot run at all. QEMU does not
+ * implement {@code io_setup(2)}, so the OSD fails to create its object store, and since Ceph 19
+ * dropped the non-AIO block device path ({@code KernelDevice.cc: "non-aio not supported"}) there
+ * is no config option that avoids it. Docker Desktop's Rosetta emulation passes the syscall
+ * through to the VM kernel and is the way to run this suite on Apple Silicon. CI runs on amd64
+ * (ubuntu-latest) where the image runs natively and this suite is expected to pass.
+ */
+@SelectPackages("com.github.vfss3.jdk.tests")
+@Suite
+@SuiteDisplayName("Ceph integration tests")
+@SuppressWarnings("NullAway")
+public class CephSuite {
+    private static final DockerImageName IMAGE = DockerImageName.parse("quay.io/ceph/demo:latest-squid");
+    private static final int RGW_PORT = 8080;
+    private static final String ACCESS_KEY = "vfs-s3-tests";
+    private static final String SECRET_KEY = "vfs-s3-tests-secret";
+
+    private static GenericContainer<?> container;
+
+    @BeforeSuite
+    static void startContainer() {
+        container = new GenericContainer<>(IMAGE)
+                // The demo entrypoint aborts without both of these. Every daemon lives in this
+                // one container and is only ever reached through the published RGW port, so the
+                // monitor can bind to loopback and the "public network" can be anything.
+                .withEnv("MON_IP", "127.0.0.1")
+                .withEnv("CEPH_PUBLIC_NETWORK", "0.0.0.0/0")
+                // MON and MGR are always bootstrapped; naming the two daemons the S3 API needs
+                // skips MDS, NFS, rbd-mirror and crash, which are pure startup cost here.
+                .withEnv("DEMO_DAEMONS", "osd rgw")
+                // Creates an RGW user with these credentials once the gateway is up.
+                .withEnv("CEPH_DEMO_UID", "vfs-s3")
+                .withEnv("CEPH_DEMO_ACCESS_KEY", ACCESS_KEY)
+                .withEnv("CEPH_DEMO_SECRET_KEY", SECRET_KEY)
+                .withEnv("RGW_NAME", "localhost")
+                // The monitor refuses to start when its data filesystem is more than 95% full.
+                // That filesystem is the Docker VM's disk, so without this the suite fails on a
+                // developer machine that merely has a lot of images cached. A throwaway
+                // single-node cluster that stores a few kilobytes has no use for the check.
+                .withEnv("CEPH_ARGS", "--mon-data-avail-crit=0 --mon-data-avail-warn=0")
+                .withExposedPorts(RGW_PORT)
+                // RGW starts listening well before the demo user exists, so waiting on the port
+                // would race the user creation and every request would come back 403. SUCCESS is
+                // the entrypoint's last line before it hands over to `ceph -w`.
+                .waitingFor(Wait.forLogMessage(".*bin/demo: SUCCESS.*", 1).withStartupTimeout(Duration.ofMinutes(5)));
+        container.start();
+
+        var endpoint = URI.create("http://" + container.getHost() + ":" + container.getMappedPort(RGW_PORT));
+        var credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY));
+
+        JdkIntegrationContext.initialize(endpoint, credentialsProvider);
+    }
+
+    @AfterSuite
+    static void stopContainer() throws Exception {
+        try {
+            JdkIntegrationContext.reset();
+        } finally {
+            if (container != null) {
+                container.stop();
+                container = null;
+            }
+        }
+    }
+}

--- a/modules/spring/src/integrationTest/java/com/github/vfss3/spring/local/CephSuite.java
+++ b/modules/spring/src/integrationTest/java/com/github/vfss3/spring/local/CephSuite.java
@@ -1,0 +1,69 @@
+package com.github.vfss3.spring.local;
+
+import com.github.vfss3.spring.SpringIntegrationContext;
+import java.net.URI;
+import java.time.Duration;
+import org.junit.platform.suite.api.*;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+/**
+ * Runs every test in {@code com.github.vfss3.spring.tests} against a freshly-started Ceph
+ * container — a single-node cluster (MON, MGR, OSD) with the RADOS Gateway, Ceph's S3 front end,
+ * on top of it. See {@code modules/jdk}'s {@code local.CephSuite} for why each environment
+ * variable below is needed, why the wait strategy keys off a log line, and why the image cannot
+ * run on an arm64 host.
+ */
+@SelectPackages("com.github.vfss3.spring.tests")
+@Suite
+@SuiteDisplayName("Ceph integration tests")
+@SuppressWarnings("NullAway")
+public class CephSuite {
+    private static final DockerImageName IMAGE = DockerImageName.parse("quay.io/ceph/demo:latest-squid");
+    private static final int RGW_PORT = 8080;
+    private static final String ACCESS_KEY = "vfs-s3-tests";
+    private static final String SECRET_KEY = "vfs-s3-tests-secret";
+
+    private static GenericContainer<?> container;
+
+    @BeforeSuite
+    static void startContainer() {
+        container = new GenericContainer<>(IMAGE)
+                // Mandatory for the demo entrypoint; everything is reached through the published
+                // RGW port, so loopback is enough.
+                .withEnv("MON_IP", "127.0.0.1")
+                .withEnv("CEPH_PUBLIC_NETWORK", "0.0.0.0/0")
+                // MON and MGR are always bootstrapped — this drops MDS, NFS, rbd-mirror and crash.
+                .withEnv("DEMO_DAEMONS", "osd rgw")
+                .withEnv("CEPH_DEMO_UID", "vfs-s3")
+                .withEnv("CEPH_DEMO_ACCESS_KEY", ACCESS_KEY)
+                .withEnv("CEPH_DEMO_SECRET_KEY", SECRET_KEY)
+                .withEnv("RGW_NAME", "localhost")
+                // Keeps the monitor from refusing to start on a nearly-full Docker VM disk.
+                .withEnv("CEPH_ARGS", "--mon-data-avail-crit=0 --mon-data-avail-warn=0")
+                .withExposedPorts(RGW_PORT)
+                // RGW listens before the demo user is created, so waiting on the port would race.
+                .waitingFor(Wait.forLogMessage(".*bin/demo: SUCCESS.*", 1).withStartupTimeout(Duration.ofMinutes(5)));
+        container.start();
+
+        var endpoint = URI.create("http://" + container.getHost() + ":" + container.getMappedPort(RGW_PORT));
+        var credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY));
+
+        SpringIntegrationContext.initialize(endpoint, credentialsProvider);
+    }
+
+    @AfterSuite
+    static void stopContainer() throws Exception {
+        try {
+            SpringIntegrationContext.reset();
+        } finally {
+            if (container != null) {
+                container.stop();
+                container = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds `CephSuite` to the `jdk`, `commons-vfs` and `spring` local backend matrices. Ceph is the first non-emulator backend there: the `quay.io/ceph/demo` image bootstraps a single-node cluster (MON, MGR, OSD) and runs the RADOS Gateway, Ceph's S3 front end, on top of it.

### Container setup

Each of these was established against a live container rather than guessed:

- `MON_IP` and `CEPH_PUBLIC_NETWORK` are mandatory — the demo entrypoint aborts without them. Everything lives in one container, so loopback is enough.
- `DEMO_DAEMONS=osd rgw` trims MDS, NFS, rbd-mirror and crash from the bootstrap. MON and MGR are always started regardless of this value.
- The wait strategy keys off the entrypoint's `SUCCESS` line, not the RGW port: the gateway listens well before the demo user exists, so a port wait would race user creation and every request would come back 403.
- `mon data avail crit` is switched off. The monitor otherwise refuses to start when its data filesystem is more than 95% full — which is the Docker VM's disk, not anything the test controls.

The rationale lives in the `jdk` suite's javadoc; the other two point at it instead of repeating it.

### ACLs

The `commons-vfs` suite keeps the platform features the parser derives for a custom endpoint rather than overriding them. MinIO, Garage, SeaweedFS and RustFS set `supportsAcl=false` because they do not implement ACLs; RGW does, so `AclTest` and `LegacyAclHandlingTest` run here. This shows up in the numbers — Ceph reports `871 passed, 2 skipped` where those four report `867 passed, 6 skipped`.

### Image

`quay.io/ceph/demo` is the only single-container Ceph distribution available. Its `ceph/ceph-container` project was archived in December 2024, so `latest-squid` (Ceph 19.2.0) is a frozen tag rather than a rolling one, and there are no version-pinned tags to use instead.

### Test plan

Verified by the three `CephSuite` cells of this PR build on `ubuntu-latest`:

| Module | Result | Time |
| --- | --- | --- |
| `jdk` | 30 tests, 29 passed, 1 skipped | 1m 18s |
| `spring` | 24 tests, 23 passed, 1 skipped | 1m 11s |
| `commons-vfs` | 873 tests, 871 passed, 2 skipped | 2m 52s |

The image is amd64-only and cannot run under QEMU at all — the OSD needs `io_setup(2)`, which QEMU does not implement, and Ceph 19 dropped the non-AIO block device path (`KernelDevice.cc: "non-aio not supported"`). On Apple Silicon it needs Docker Desktop's Rosetta emulation; CI runs it natively.

Badges start as "pending" and get their first real status from the `17.0` run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)